### PR TITLE
Add magnitude synonym functions for ease of use

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1166,6 +1166,26 @@ impl<N: Real, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         self.norm_squared().sqrt()
     }
 
+    /// A synonym for the norm of this matrix.
+    ///
+    /// Aka the length.
+    ///
+    /// This function is simply implemented as a call to `norm()`
+    #[inline]
+    pub fn magnitude(&self) -> N {
+        self.norm()
+    }
+
+    /// A synonym for the squared norm of this matrix.
+    ///
+    /// Aka the squared length.
+    ///
+    /// This function is simply implemented as a call to `norm_squared()`
+    #[inline]
+    pub fn magnitude_squared(&self) -> N {
+        self.norm_squared()
+    }
+
     /// Returns a normalized version of this matrix.
     #[inline]
     pub fn normalize(&self) -> MatrixMN<N, R, C>

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -176,6 +176,26 @@ impl<N: Real> Quaternion<N> {
         self.coords.norm()
     }
 
+    /// A synonym for the norm of this quaternion.
+    ///
+    /// Aka the length.
+    ///
+    /// This function is simply implemented as a call to `norm()`
+    #[inline]
+    pub fn magnitude(&self) -> N {
+        self.norm()
+    }
+
+    /// A synonym for the squared norm of this quaternion.
+    ///
+    /// Aka the squared length.
+    ///
+    /// This function is simply implemented as a call to `norm_squared()`
+    #[inline]
+    pub fn magnitude_squared(&self) -> N {
+        self.norm_squared()
+    }
+
     /// The squared norm of this quaternion.
     #[inline]
     pub fn norm_squared(&self) -> N {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,18 @@ pub fn norm_squared<V: NormedSpace>(v: &V) -> V::Field {
     v.norm_squared()
 }
 
+/// A synonym function for `norm()` aka length.
+#[inline]
+pub fn magnitude<V: NormedSpace>(v: &V) -> V::Field {
+    v.norm()
+}
+
+/// A synonym function for `norm_squared()` aka length squared.
+#[inline]
+pub fn magnitude_squared<V: NormedSpace>(v: &V) -> V::Field {
+    v.norm_squared()
+}
+
 /// Computes the normalized version of the vector `v`.
 #[inline]
 pub fn normalize<V: NormedSpace>(v: &V) -> V {


### PR DESCRIPTION
No new math here, just adding some common synonyms for the `norm()` functions.  I didn't know to look for the name `norm()` when browsing the docs so I got pretty confused.  The name `magnitude` is much more common in other math libraries I've used so these names are more intuitive to me.