### PR TITLE
Rollup of minor feature additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
   * Add `.copy_from_slice` to copy matrix components from a slice in column-major order.
+  * Add `.dot` to quaternions.
+  * Add `.zip_zip_map` for iterating on three matrices simultaneously, and applying a closure to them.
+  * Add `.slerp` and `.try_slerp` to unit vectors.
 
 ## [0.16.0]
 All dependencies have been updated to their latest versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * Add `.dot` to quaternions.
   * Add `.zip_zip_map` for iterating on three matrices simultaneously, and applying a closure to them.
   * Add `.slerp` and `.try_slerp` to unit vectors.
+  * Add `.to_projective` and `.as_projective` to `Perspective3` and `Orthographic3` in order to
+  use them as `Projective3` structures.
 
 ## [0.16.0]
 All dependencies have been updated to their latest versions.

--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -15,12 +15,12 @@ use base::allocator::Allocator;
 use geometry::{Isometry, IsometryMatrix3, Orthographic3, Perspective3, Point, Point3, Rotation2,
                Rotation3};
 
-use alga::general::{Field, Real};
+use alga::general::{Ring, Real};
 use alga::linear::Transformation;
 
 impl<N, D: DimName> MatrixN<N, D>
 where
-    N: Scalar + Field,
+    N: Scalar + Ring,
     DefaultAllocator: Allocator<N, D, D>,
 {
     /// Creates a new homogeneous matrix that applies the same scaling factor on each dimension.
@@ -144,7 +144,7 @@ impl<N: Real> Matrix4<N> {
     }
 }
 
-impl<N: Scalar + Field, D: DimName, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
+impl<N: Scalar + Ring, D: DimName, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
     /// Computes the transformation equal to `self` followed by an uniform scaling factor.
     #[inline]
     pub fn append_scaling(&self, scaling: N) -> MatrixN<N, D>
@@ -231,7 +231,7 @@ impl<N: Scalar + Field, D: DimName, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
     }
 }
 
-impl<N: Scalar + Field, D: DimName, S: StorageMut<N, D, D>> SquareMatrix<N, D, S> {
+impl<N: Scalar + Ring, D: DimName, S: StorageMut<N, D, D>> SquareMatrix<N, D, S> {
     /// Computes in-place the transformation equal to `self` followed by an uniform scaling factor.
     #[inline]
     pub fn append_scaling_mut(&mut self, scaling: N)

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -5,6 +5,7 @@ use rand::Rng;
 #[cfg(feature = "serde-serialize")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use std::fmt;
+use std::mem;
 
 use alga::general::Real;
 
@@ -13,7 +14,7 @@ use base::helper;
 use base::storage::Storage;
 use base::{Matrix4, Vector, Vector3};
 
-use geometry::Point3;
+use geometry::{Projective3, Point3};
 
 /// A 3D orthographic projection stored as an homogeneous 4x4 matrix.
 pub struct Orthographic3<N: Real> {
@@ -156,6 +157,18 @@ impl<N: Real> Orthographic3<N> {
     #[inline]
     pub fn as_matrix(&self) -> &Matrix4<N> {
         &self.matrix
+    }
+
+    /// A reference to this transformation seen as a `Projective3`.
+    #[inline]
+    pub fn as_projective(&self) -> &Projective3<N> {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// This transformation seen as a `Projective3`.
+    #[inline]
+    pub fn to_projective(&self) -> Projective3<N> {
+        Projective3::from_matrix_unchecked(self.matrix)
     }
 
     /// Retrieves the underlying homogeneous matrix.

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -6,6 +6,7 @@ use rand::Rng;
 #[cfg(feature = "serde-serialize")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use std::fmt;
+use std::mem;
 
 use alga::general::Real;
 
@@ -14,7 +15,7 @@ use base::helper;
 use base::storage::Storage;
 use base::{Matrix4, Scalar, Vector, Vector3};
 
-use geometry::Point3;
+use geometry::{Projective3, Point3};
 
 /// A 3D perspective projection stored as an homogeneous 4x4 matrix.
 pub struct Perspective3<N: Scalar> {
@@ -128,6 +129,18 @@ impl<N: Real> Perspective3<N> {
     #[inline]
     pub fn as_matrix(&self) -> &Matrix4<N> {
         &self.matrix
+    }
+
+    /// A reference to this transformation seen as a `Projective3`.
+    #[inline]
+    pub fn as_projective(&self) -> &Projective3<N> {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// This transformation seen as a `Projective3`.
+    #[inline]
+    pub fn to_projective(&self) -> Projective3<N> {
+        Projective3::from_matrix_unchecked(self.matrix)
     }
 
     /// Retrieves the underlying homogeneous matrix.

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -202,6 +202,12 @@ impl<N: Real> Quaternion<N> {
         self.coords.norm_squared()
     }
 
+    /// The dot product of two quaternions.
+    #[inline]
+    pub fn dot(&self, rhs: &Self) -> N {
+        self.coords.dot(&rhs.coords)
+    }
+
     /// The polar decomposition of this quaternion.
     ///
     /// Returns, from left to right: the quaternion norm, the half rotation angle, the rotation


### PR DESCRIPTION
As stated on the change log, this:
  * adds `.dot` to quaternions.
  * adds `.zip_zip_map` for iterating on three matrices simultaneously, and applying a closure to them.
  * adds `.slerp` and `.try_slerp` to unit vectors.
  * adds `.to_projective` and `.as_projective` to `Perspective3` and `Orthographic3` in order to
  use them as `Projective3` structures (related to #392).