### PR TITLE
Fix typo in GLM Mat4 docs

### DIFF
--- a/nalgebra-glm/src/aliases.rs
+++ b/nalgebra-glm/src/aliases.rs
@@ -199,7 +199,7 @@ pub type Mat4x2 = Matrix4x2<f32>;
 pub type Mat4x3 = Matrix4x3<f32>;
 /// A 4x4 matrix with `f32` components.
 pub type Mat4x4 = Matrix4<f32>;
-/// A 4x3 matrix with `f32` components.
+/// A 4x4 matrix with `f32` components.
 pub type Mat4 = Matrix4<f32>;
 
 /// A quaternion with f32 components.


### PR DESCRIPTION
Was reading through the docs for the new GLM library (which looks fantastic, by the way - looking forward to trying it out!) and spotted a very small typo/copy and paste error  - it says that `Mat4` is a 4x3 matrix, rather than a 4x4 matrix.