### PR TITLE
Add `Into` impls for converting `MatrixSlice`s into `MatrixMN`s

### DIFF
--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -5,12 +5,16 @@ use std::convert::{AsMut, AsRef, From, Into};
 use std::mem;
 use std::ptr;
 
+use std::ops::Mul;
+use typenum::Prod;
+use generic_array::ArrayLength;
+
 use base::allocator::{Allocator, SameShapeAllocator};
 use base::constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
-use base::dimension::{Dim, U1, U10, U11, U12, U13, U14, U15, U16, U2, U3, U4, U5, U6, U7, U8, U9};
+use base::dimension::{Dim, DimName, Dynamic, U1, U10, U11, U12, U13, U14, U15, U16, U2, U3, U4, U5, U6, U7, U8, U9};
 use base::iter::{MatrixIter, MatrixIterMut};
 use base::storage::{ContiguousStorage, ContiguousStorageMut, Storage, StorageMut};
-use base::{DefaultAllocator, Matrix, MatrixMN, Scalar};
+use base::{DefaultAllocator, Matrix, MatrixMN, MatrixArray, MatrixSlice, MatrixSliceMut, MatrixVec, Scalar};
 
 // FIXME: too bad this won't work allo slice conversions.
 impl<N1, N2, R1, C1, R2, C2> SubsetOf<MatrixMN<N2, R2, C2>> for MatrixMN<N1, R1, C1>
@@ -326,3 +330,94 @@ impl_from_into_mint_2D!(
     (U3, U4) => ColumnMatrix3x4{x, y, z}[3];
     (U4, U4) => ColumnMatrix4{x, y, z, w}[4];
 );
+
+
+impl<'a, N, R, C, RStride, CStride> From<MatrixSlice<'a, N, R, C, RStride, CStride>>
+    for Matrix<N, R, C, MatrixArray<N, R, C>>
+where
+    N: Scalar,
+    R: DimName,
+    C: DimName,
+    RStride: Dim,
+    CStride: Dim,
+    R::Value: Mul<C::Value>,
+    Prod<R::Value, C::Value>: ArrayLength<N>,
+{
+    fn from(matrix_slice: MatrixSlice<'a, N, R, C, RStride, CStride>) -> Self
+    {
+        matrix_slice.into_owned()
+    }
+}
+
+impl<'a, N, C, RStride, CStride> From<MatrixSlice<'a, N, Dynamic, C, RStride, CStride>>
+    for Matrix<N, Dynamic, C, MatrixVec<N, Dynamic, C>>
+where
+    N: Scalar,
+    C: Dim,
+    RStride: Dim,
+    CStride: Dim,
+{
+    fn from(matrix_slice: MatrixSlice<'a, N, Dynamic, C, RStride, CStride>) -> Self
+    {
+        matrix_slice.into_owned()
+    }
+}
+
+impl<'a, N, R, RStride, CStride> From<MatrixSlice<'a, N, R, Dynamic, RStride, CStride>>
+    for Matrix<N, R, Dynamic, MatrixVec<N, R, Dynamic>>
+where
+    N: Scalar,
+    R: DimName,
+    RStride: Dim,
+    CStride: Dim,
+{
+    fn from(matrix_slice: MatrixSlice<'a, N, R, Dynamic, RStride, CStride>) -> Self
+    {
+        matrix_slice.into_owned()
+    }
+}
+
+impl<'a, N, R, C, RStride, CStride> From<MatrixSliceMut<'a, N, R, C, RStride, CStride>>
+    for Matrix<N, R, C, MatrixArray<N, R, C>>
+where
+    N: Scalar,
+    R: DimName,
+    C: DimName,
+    RStride: Dim,
+    CStride: Dim,
+    R::Value: Mul<C::Value>,
+    Prod<R::Value, C::Value>: ArrayLength<N>,
+{
+    fn from(matrix_slice: MatrixSliceMut<'a, N, R, C, RStride, CStride>) -> Self
+    {
+        matrix_slice.into_owned()
+    }
+}
+
+impl<'a, N, C, RStride, CStride> From<MatrixSliceMut<'a, N, Dynamic, C, RStride, CStride>>
+    for Matrix<N, Dynamic, C, MatrixVec<N, Dynamic, C>>
+where
+    N: Scalar,
+    C: Dim,
+    RStride: Dim,
+    CStride: Dim,
+{
+    fn from(matrix_slice: MatrixSliceMut<'a, N, Dynamic, C, RStride, CStride>) -> Self
+    {
+        matrix_slice.into_owned()
+    }
+}
+
+impl<'a, N, R, RStride, CStride> From<MatrixSliceMut<'a, N, R, Dynamic, RStride, CStride>>
+    for Matrix<N, R, Dynamic, MatrixVec<N, R, Dynamic>>
+where
+    N: Scalar,
+    R: DimName,
+    RStride: Dim,
+    CStride: Dim,
+{
+    fn from(matrix_slice: MatrixSliceMut<'a, N, R, Dynamic, RStride, CStride>) -> Self
+    {
+        matrix_slice.into_owned()
+    }
+}

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -343,12 +343,12 @@ where
     R::Value: Mul<C::Value>,
     Prod<R::Value, C::Value>: ArrayLength<N>,
 {
-    fn from(matrix_slice: MatrixSlice<'a, N, R, C, RStride, CStride>) -> Self
-    {
+    fn from(matrix_slice: MatrixSlice<'a, N, R, C, RStride, CStride>) -> Self {
         matrix_slice.into_owned()
     }
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, C, RStride, CStride> From<MatrixSlice<'a, N, Dynamic, C, RStride, CStride>>
     for Matrix<N, Dynamic, C, MatrixVec<N, Dynamic, C>>
 where
@@ -357,12 +357,12 @@ where
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_slice: MatrixSlice<'a, N, Dynamic, C, RStride, CStride>) -> Self
-    {
+    fn from(matrix_slice: MatrixSlice<'a, N, Dynamic, C, RStride, CStride>) -> Self {
         matrix_slice.into_owned()
     }
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, R, RStride, CStride> From<MatrixSlice<'a, N, R, Dynamic, RStride, CStride>>
     for Matrix<N, R, Dynamic, MatrixVec<N, R, Dynamic>>
 where
@@ -371,8 +371,7 @@ where
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_slice: MatrixSlice<'a, N, R, Dynamic, RStride, CStride>) -> Self
-    {
+    fn from(matrix_slice: MatrixSlice<'a, N, R, Dynamic, RStride, CStride>) -> Self {
         matrix_slice.into_owned()
     }
 }
@@ -388,12 +387,12 @@ where
     R::Value: Mul<C::Value>,
     Prod<R::Value, C::Value>: ArrayLength<N>,
 {
-    fn from(matrix_slice: MatrixSliceMut<'a, N, R, C, RStride, CStride>) -> Self
-    {
+    fn from(matrix_slice: MatrixSliceMut<'a, N, R, C, RStride, CStride>) -> Self {
         matrix_slice.into_owned()
     }
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, C, RStride, CStride> From<MatrixSliceMut<'a, N, Dynamic, C, RStride, CStride>>
     for Matrix<N, Dynamic, C, MatrixVec<N, Dynamic, C>>
 where
@@ -408,6 +407,7 @@ where
     }
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, R, RStride, CStride> From<MatrixSliceMut<'a, N, R, Dynamic, RStride, CStride>>
     for Matrix<N, R, Dynamic, MatrixVec<N, R, Dynamic>>
 where
@@ -416,8 +416,7 @@ where
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_slice: MatrixSliceMut<'a, N, R, Dynamic, RStride, CStride>) -> Self
-    {
+    fn from(matrix_slice: MatrixSliceMut<'a, N, R, Dynamic, RStride, CStride>) -> Self {
         matrix_slice.into_owned()
     }
 }

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -14,7 +14,9 @@ use base::constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
 use base::dimension::{Dim, DimName, Dynamic, U1, U10, U11, U12, U13, U14, U15, U16, U2, U3, U4, U5, U6, U7, U8, U9};
 use base::iter::{MatrixIter, MatrixIterMut};
 use base::storage::{ContiguousStorage, ContiguousStorageMut, Storage, StorageMut};
-use base::{DefaultAllocator, Matrix, MatrixMN, MatrixArray, MatrixSlice, MatrixSliceMut, MatrixVec, Scalar};
+use base::{DefaultAllocator, Matrix, MatrixMN, MatrixArray, MatrixSlice, MatrixSliceMut, Scalar};
+#[cfg(any(feature = "std", feature = "alloc"))]
+use base::MatrixVec;
 
 // FIXME: too bad this won't work allo slice conversions.
 impl<N1, N2, R1, C1, R2, C2> SubsetOf<MatrixMN<N2, R2, C2>> for MatrixMN<N1, R1, C1>


### PR DESCRIPTION
Resolves #342 by adding a bunch of `From` impls.

The fact that this couldn't be accomplished with one, more generic `From` impl has some consequences:
 - All the additional impls add visual noise to the rustdoc.
 - If you get used to using `.into()` for this purpose, you might be surprised that it stops working when you try to write more generic code over `MatrixMN`s (and you need to use the `into_owned` method instead).