### PR TITLE
Change the SVD methods to return a Result instead of panicking

### DIFF
--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -490,10 +490,7 @@ where
     /// computed at construction-time.
     pub fn recompose(self) -> Result<MatrixMN<N, R, C>, &'static str> {
         match (self.u, self.v_t) {
-            (Some(_u), Some(_v_t)) => {
-                let mut u = _u;
-                let v_t = _v_t;
-
+            (Some(mut u), Some(v_t)) => {
                 for i in 0..self.singular_values.len() {
                     let val = self.singular_values[i];
                     u.column_mut(i).mul_assign(val);

--- a/tests/linalg/svd.rs
+++ b/tests/linalg/svd.rs
@@ -9,7 +9,7 @@ mod quickcheck_tests {
         fn svd(m: DMatrix<f64>) -> bool {
             if m.len() > 0 {
                 let svd = m.clone().svd(true, true);
-                let recomp_m = svd.clone().recompose();
+                let recomp_m = svd.clone().recompose().unwrap();
                 let (u, s, v_t) = (svd.u.unwrap(), svd.singular_values, svd.v_t.unwrap());
                 let ds = DMatrix::from_diagonal(&s);
 
@@ -90,7 +90,7 @@ mod quickcheck_tests {
         fn svd_pseudo_inverse(m: DMatrix<f64>) -> bool {
             if m.len() > 0 {
                 let svd = m.clone().svd(true, true);
-                let pinv = svd.pseudo_inverse(1.0e-10);
+                let pinv = svd.pseudo_inverse(1.0e-10).unwrap();
 
                 if m.nrows() > m.ncols() {
                     println!("{}", &pinv * &m);
@@ -117,10 +117,10 @@ mod quickcheck_tests {
                 let b1 = DVector::new_random(n);
                 let b2 = DMatrix::new_random(n, nb);
 
-                let sol1 = svd.solve(&b1, 1.0e-7);
-                let sol2 = svd.solve(&b2, 1.0e-7);
+                let sol1 = svd.solve(&b1, 1.0e-7).unwrap();
+                let sol2 = svd.solve(&b2, 1.0e-7).unwrap();
 
-                let recomp = svd.recompose();
+                let recomp = svd.recompose().unwrap();
                 if !relative_eq!(m, recomp, epsilon = 1.0e-6) {
                     println!("{}{}", m, recomp);
                 }
@@ -262,22 +262,22 @@ fn svd_singular_horizontal() {
 fn svd_zeros() {
     let m = DMatrix::from_element(10, 10, 0.0);
     let svd = m.clone().svd(true, true);
-    assert_eq!(m, svd.recompose());
+    assert_eq!(Ok(m), svd.recompose());
 }
 
 #[test]
 fn svd_identity() {
     let m = DMatrix::<f64>::identity(10, 10);
     let svd = m.clone().svd(true, true);
-    assert_eq!(m, svd.recompose());
+    assert_eq!(Ok(m), svd.recompose());
 
     let m = DMatrix::<f64>::identity(10, 15);
     let svd = m.clone().svd(true, true);
-    assert_eq!(m, svd.recompose());
+    assert_eq!(Ok(m), svd.recompose());
 
     let m = DMatrix::<f64>::identity(15, 10);
     let svd = m.clone().svd(true, true);
-    assert_eq!(m, svd.recompose());
+    assert_eq!(Ok(m), svd.recompose());
 }
 
 #[test]
@@ -294,7 +294,7 @@ fn svd_with_delimited_subproblem() {
     m[(8,8)] = 16.0; m[(3,9)] = 17.0;
     m[(9,9)] = 18.0;
     let svd = m.clone().svd(true, true);
-    assert!(relative_eq!(m, svd.recompose(), epsilon = 1.0e-7));
+    assert!(relative_eq!(m, svd.recompose().unwrap(), epsilon = 1.0e-7));
 
     // Rectangular versions.
     let mut m = DMatrix::<f64>::from_element(15, 10, 0.0);
@@ -309,10 +309,10 @@ fn svd_with_delimited_subproblem() {
     m[(8,8)] = 16.0; m[(3,9)] = 17.0;
     m[(9,9)] = 18.0;
     let svd = m.clone().svd(true, true);
-    assert!(relative_eq!(m, svd.recompose(), epsilon = 1.0e-7));
+    assert!(relative_eq!(m, svd.recompose().unwrap(), epsilon = 1.0e-7));
 
     let svd = m.transpose().svd(true, true);
-    assert!(relative_eq!(m.transpose(), svd.recompose(), epsilon = 1.0e-7));
+    assert!(relative_eq!(m.transpose(), svd.recompose().unwrap(), epsilon = 1.0e-7));
 }
 
 #[test]
@@ -328,7 +328,15 @@ fn svd_fail() {
     println!("Singular values: {}", svd.singular_values);
     println!("u: {:.5}", svd.u.unwrap());
     println!("v: {:.5}", svd.v_t.unwrap());
-    let recomp = svd.recompose();
+    let recomp = svd.recompose().unwrap();
     println!("{:.5}{:.5}", m, recomp);
     assert!(relative_eq!(m, recomp, epsilon = 1.0e-5));
+}
+
+#[test]
+fn svd_err() {
+    let m = DMatrix::from_element(10, 10, 0.0);
+    let svd = m.clone().svd(false, false);
+    assert_eq!(Err("SVD recomposition: U and V^t have not been computed."), svd.clone().recompose());
+    assert_eq!(Err("SVD pseudo inverse: the epsilon must be non-negative."), svd.clone().pseudo_inverse(-1.0));
 }


### PR DESCRIPTION
Fix #358.

I changed the SVD methods to return a `Result` instead of an `Option`, since there are multiple types of errors. Knowing the error message might be useful.

I'm pretty new to rust and nalgebra, so I'm not sure if I'm doing everything right. For example, some questions in my mind right now:
* Should I also change the return types of the methods in `nalgebra-lapack/src/svd.rs`?
* Is is OK to return a `Result<MatrixMN<N, R, C>, &'static str>`:
  * Should I return a custom error type?
  * Is it OK for the lifetime of that string slice to be `static` (I'm pretty much a noob when it comes to lifetimes)? Should I return a `String` instead?