### PR TITLE
Fix partial_cmp

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -894,8 +894,12 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.shape() != other.shape() || self.nrows() == 0 || self.ncols() == 0 {
+        if self.shape() != other.shape() {
             return None;
+        }
+
+        if self.nrows() == 0 || self.ncols() == 0 {
+            return Some(Ordering::Equal);
         }
 
         let mut first_ord = unsafe {

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -894,18 +894,17 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        assert!(
-            self.shape() == other.shape(),
-            "Matrix comparison error: dimensions mismatch."
-        );
+        if self.shape() != other.shape() || self.nrows() == 0 || self.ncols() == 0 {
+            return None;
+        }
 
-        let first_ord = unsafe {
+        let mut first_ord = unsafe {
             self.data
                 .get_unchecked_linear(0)
                 .partial_cmp(other.data.get_unchecked_linear(0))
         };
 
-        if let Some(mut first_ord) = first_ord {
+        if let Some(first_ord) = first_ord.as_mut() {
             let mut it = self.iter().zip(other.iter());
             let _ = it.next(); // Drop the first elements (we already tested it).
 
@@ -914,16 +913,16 @@ where
                     match ord {
                         Ordering::Equal => { /* Does not change anything. */ }
                         Ordering::Less => {
-                            if first_ord == Ordering::Greater {
+                            if *first_ord == Ordering::Greater {
                                 return None;
                             }
-                            first_ord = ord
+                            *first_ord = ord
                         }
                         Ordering::Greater => {
-                            if first_ord == Ordering::Less {
+                            if *first_ord == Ordering::Less {
                                 return None;
                             }
-                            first_ord = ord
+                            *first_ord = ord
                         }
                     }
                 } else {
@@ -976,8 +975,7 @@ impl<N, R: Dim, C: Dim, S> Eq for Matrix<N, R, C, S>
 where
     N: Scalar + Eq,
     S: Storage<N, R, C>,
-{
-}
+{}
 
 impl<N, R: Dim, C: Dim, S> PartialEq for Matrix<N, R, C, S>
 where

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -726,7 +726,6 @@ fn partial_clamp() {
 
 #[test]
 fn partial_cmp() {
-    // NOTE: from #401.
     let a = Vector2::new(1.0, 6.0);
     let b = Vector2::new(1.0, 3.0);
     let c = Vector2::new(2.0, 7.0);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1,4 +1,5 @@
 use num::{One, Zero};
+use std::cmp::Ordering;
 
 use na::dimension::{U15, U8};
 use na::{
@@ -721,6 +722,19 @@ fn partial_clamp() {
     let max = Vector2::new(75.0, 0.0);
     let inter = na::partial_clamp(&n, &min, &max);
     assert_eq!(*inter.unwrap(), n);
+}
+
+#[test]
+fn partial_cmp() {
+    // NOTE: from #401.
+    let a = Vector2::new(1.0, 6.0);
+    let b = Vector2::new(1.0, 3.0);
+    let c = Vector2::new(2.0, 7.0);
+    let d = Vector2::new(0.0, 7.0);
+    assert_eq!(a.partial_cmp(&a), Some(Ordering::Equal));
+    assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));
+    assert_eq!(a.partial_cmp(&c), Some(Ordering::Less));
+    assert_eq!(a.partial_cmp(&d), None);
 }
 
 #[test]


### PR DESCRIPTION
The implemented ordering is such that two matrices `A, B` are `Ordering::Less` iff. all `A[(i, j)] <= B[(i, j)]`. Similar rules apply for greater and equal. If there exists some components such that `A[(i1, j1)] < B[(i1, j1)])` and some other components such that `A[(i2, j2)] > B[(i2, j2)])`, then the ordering is `None`.