### PR TITLE
Add doc-test for BLAS operations.

### DIFF
--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -16,6 +16,14 @@ use base::{DefaultAllocator, Matrix, Scalar, SquareMatrix, Vector};
 impl<N: Scalar + PartialOrd + Signed, D: Dim, S: Storage<N, D>> Vector<N, D, S> {
 
     /// Computes the index of the vector component with the largest value.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Vector3;
+    /// let vec = Vector3::new(11, -15, 13);
+    /// assert_eq!(vec.imax(), 2);
+    /// ```
     #[inline]
     pub fn imax(&self) -> usize {
         assert!(!self.is_empty(), "The input vector must not be empty.");
@@ -36,6 +44,14 @@ impl<N: Scalar + PartialOrd + Signed, D: Dim, S: Storage<N, D>> Vector<N, D, S> 
     }
 
     /// Computes the index of the vector component with the largest absolute value.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Vector3;
+    /// let vec = Vector3::new(11, -15, 13);
+    /// assert_eq!(vec.iamax(), 1);
+    /// ```
     #[inline]
     pub fn iamax(&self) -> usize {
         assert!(!self.is_empty(), "The input vector must not be empty.");
@@ -56,6 +72,14 @@ impl<N: Scalar + PartialOrd + Signed, D: Dim, S: Storage<N, D>> Vector<N, D, S> 
     }
 
     /// Computes the index of the vector component with the smallest value.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Vector3;
+    /// let vec = Vector3::new(11, -15, 13);
+    /// assert_eq!(vec.imin(), 1);
+    /// ```
     #[inline]
     pub fn imin(&self) -> usize {
         assert!(!self.is_empty(), "The input vector must not be empty.");
@@ -76,6 +100,14 @@ impl<N: Scalar + PartialOrd + Signed, D: Dim, S: Storage<N, D>> Vector<N, D, S> 
     }
 
     /// Computes the index of the vector component with the smallest absolute value.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Vector3;
+    /// let vec = Vector3::new(11, -15, 13);
+    /// assert_eq!(vec.iamin(), 0);
+    /// ```
     #[inline]
     pub fn iamin(&self) -> usize {
         assert!(!self.is_empty(), "The input vector must not be empty.");
@@ -98,6 +130,15 @@ impl<N: Scalar + PartialOrd + Signed, D: Dim, S: Storage<N, D>> Vector<N, D, S> 
 
 impl<N: Scalar + PartialOrd + Signed, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// Computes the index of the matrix component with the largest absolute value.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Matrix2x3;
+    /// let mat = Matrix2x3::new(11, -12, 13,
+    ///                          21, 22, -23);
+    /// assert_eq!(mat.iamax_full(), (1, 2));
+    /// ```
     #[inline]
     pub fn iamax_full(&self) -> (usize, usize) {
         assert!(!self.is_empty(), "The input matrix must not be empty.");
@@ -124,10 +165,26 @@ impl<N, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S>
 where
     N: Scalar + Zero + ClosedAdd + ClosedMul,
 {
-    /// The dot product between two matrices (seen as vectors).
+    /// The dot product between two vectors or matrices (seen as vectors).
     ///
     /// Note that this is **not** the matrix multiplication as in, e.g., numpy. For matrix
     /// multiplication, use one of: `.gemm`, `mul_to`, `.mul`, `*`.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Vector3, Matrix2x3};
+    ///
+    /// let vec1 = Vector3::new(1.0, 2.0, 3.0);
+    /// let vec2 = Vector3::new(0.1, 0.2, 0.3);
+    /// assert_eq!(vec1.dot(&vec2), 1.4);
+    ///
+    /// let mat1 = Matrix2x3::new(1.0, 2.0, 3.0,
+    ///                           4.0, 5.0, 6.0);
+    /// let mat2 = Matrix2x3::new(0.1, 0.2, 0.3,
+    ///                           0.4, 0.5, 0.6);
+    /// assert_eq!(mat1.dot(&mat2), 9.1);
+    /// ```
     #[inline]
     pub fn dot<R2: Dim, C2: Dim, SB>(&self, rhs: &Matrix<N, R2, C2, SB>) -> N
     where
@@ -228,6 +285,23 @@ where
     }
 
     /// The dot product between the transpose of `self` and `rhs`.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Vector3, RowVector3, Matrix2x3, Matrix3x2};
+    ///
+    /// let vec1 = Vector3::new(1.0, 2.0, 3.0);
+    /// let vec2 = RowVector3::new(0.1, 0.2, 0.3);
+    /// assert_eq!(vec1.tr_dot(&vec2), 1.4);
+    ///
+    /// let mat1 = Matrix2x3::new(1.0, 2.0, 3.0,
+    ///                           4.0, 5.0, 6.0);
+    /// let mat2 = Matrix3x2::new(0.1, 0.4,
+    ///                           0.2, 0.5,
+    ///                           0.3, 0.6);
+    /// assert_eq!(mat1.tr_dot(&mat2), 9.1);
+    /// ```
     #[inline]
     pub fn tr_dot<R2: Dim, C2: Dim, SB>(&self, rhs: &Matrix<N, R2, C2, SB>) -> N
     where
@@ -283,6 +357,17 @@ where
     /// Computes `self = a * x + b * self`.
     ///
     /// If be is zero, `self` is never read from.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Vector3;
+    ///
+    /// let mut vec1 = Vector3::new(1.0, 2.0, 3.0);
+    /// let vec2 = Vector3::new(0.1, 0.2, 0.3);
+    /// vec1.axpy(10.0, &vec2, 5.0);
+    /// assert_eq!(vec1, Vector3::new(6.0, 12.0, 18.0));
+    /// ```
     #[inline]
     pub fn axpy<D2: Dim, SB>(&mut self, a: N, x: &Vector<N, D2, SB>, b: N)
     where

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -168,7 +168,7 @@ where
     /// The dot product between two vectors or matrices (seen as vectors).
     ///
     /// Note that this is **not** the matrix multiplication as in, e.g., numpy. For matrix
-    /// multiplication, use one of: `.gemm`, `mul_to`, `.mul`, `*`.
+    /// multiplication, use one of: `.gemm`, `.mul_to`, `.mul`, the `*` operator.
     ///
     /// # Examples:
     ///

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -174,7 +174,6 @@ where
     ///
     /// ```
     /// # use nalgebra::{Vector3, Matrix2x3};
-    ///
     /// let vec1 = Vector3::new(1.0, 2.0, 3.0);
     /// let vec2 = Vector3::new(0.1, 0.2, 0.3);
     /// assert_eq!(vec1.dot(&vec2), 1.4);
@@ -290,7 +289,6 @@ where
     ///
     /// ```
     /// # use nalgebra::{Vector3, RowVector3, Matrix2x3, Matrix3x2};
-    ///
     /// let vec1 = Vector3::new(1.0, 2.0, 3.0);
     /// let vec2 = RowVector3::new(0.1, 0.2, 0.3);
     /// assert_eq!(vec1.tr_dot(&vec2), 1.4);
@@ -362,7 +360,6 @@ where
     ///
     /// ```
     /// # use nalgebra::Vector3;
-    ///
     /// let mut vec1 = Vector3::new(1.0, 2.0, 3.0);
     /// let vec2 = Vector3::new(0.1, 0.2, 0.3);
     /// vec1.axpy(10.0, &vec2, 5.0);
@@ -393,6 +390,18 @@ where
     /// `alpha, beta` two scalars.
     ///
     /// If `beta` is zero, `self` is never read.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Matrix2, Vector2};
+    /// let mut vec1 = Vector2::new(1.0, 2.0);
+    /// let vec2 = Vector2::new(0.1, 0.2);
+    /// let mat = Matrix2::new(1.0, 2.0,
+    ///                        3.0, 4.0);
+    /// vec1.gemv(10.0, &mat, &vec2, 5.0);
+    /// assert_eq!(vec1, Vector2::new(10.0, 21.0));
+    /// ```
     #[inline]
     pub fn gemv<R2: Dim, C2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -437,6 +446,28 @@ where
     ///
     /// If `beta` is zero, `self` is never read. If `self` is read, only its lower-triangular part
     /// (including the diagonal) is actually read.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Matrix2, Vector2};
+    /// let mat = Matrix2::new(1.0, 2.0,
+    ///                        2.0, 4.0);
+    /// let mut vec1 = Vector2::new(1.0, 2.0);
+    /// let vec2 = Vector2::new(0.1, 0.2);
+    /// vec1.gemv_symm(10.0, &mat, &vec2, 5.0);
+    /// assert_eq!(vec1, Vector2::new(10.0, 20.0));
+    ///
+    ///
+    /// // The matrix upper-triangular elements can be garbage because it is never
+    /// // read by this method. Therefore, it is not necessary for the caller to
+    /// // fill the matrix struct upper-triangle.
+    /// let mat = Matrix2::new(1.0, 9999999.9999999,
+    ///                        2.0, 4.0);
+    /// let mut vec1 = Vector2::new(1.0, 2.0);
+    /// vec1.gemv_symm(10.0, &mat, &vec2, 5.0);
+    /// assert_eq!(vec1, Vector2::new(10.0, 20.0));
+    /// ```
     #[inline]
     pub fn gemv_symm<D2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -491,6 +522,20 @@ where
     /// `alpha, beta` two scalars.
     ///
     /// If `beta` is zero, `self` is never read.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Matrix2, Vector2};
+    /// let mat = Matrix2::new(1.0, 3.0,
+    ///                        2.0, 4.0);
+    /// let mut vec1 = Vector2::new(1.0, 2.0);
+    /// let vec2 = Vector2::new(0.1, 0.2);
+    /// let expected = mat.transpose() * vec2 * 10.0 + vec1 * 5.0;
+    ///
+    /// vec1.gemv_tr(10.0, &mat, &vec2, 5.0);
+    /// assert_eq!(vec1, expected);
+    /// ```
     #[inline]
     pub fn gemv_tr<R2: Dim, C2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -538,6 +583,19 @@ where
     /// Computes `self = alpha * x * y.transpose() + beta * self`.
     ///
     /// If `beta` is zero, `self` is never read.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Matrix2x3, Vector2, Vector3};
+    /// let mut mat = Matrix2x3::repeat(4.0);
+    /// let vec1 = Vector2::new(1.0, 2.0);
+    /// let vec2 = Vector3::new(0.1, 0.2, 0.3);
+    /// let expected = vec1 * vec2.transpose() * 10.0 + mat * 5.0;
+    ///
+    /// mat.ger(10.0, &vec1, &vec2, 5.0);
+    /// assert_eq!(mat, expected);
+    /// ```
     #[inline]
     pub fn ger<D2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -571,6 +629,24 @@ where
     /// `alpha` and `beta` are scalar.
     ///
     /// If `beta` is zero, `self` is never read.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # extern crate nalgebra;
+    /// # use nalgebra::{Matrix2x3, Matrix3x4, Matrix2x4};
+    /// let mut mat1 = Matrix2x4::identity();
+    /// let mat2 = Matrix2x3::new(1.0, 2.0, 3.0,
+    ///                           4.0, 5.0, 6.0);
+    /// let mat3 = Matrix3x4::new(0.1, 0.2, 0.3, 0.4,
+    ///                           0.5, 0.6, 0.7, 0.8,
+    ///                           0.9, 1.0, 1.1, 1.2);
+    /// let expected = mat2 * mat3 * 10.0 + mat1 * 5.0;
+    ///
+    /// mat1.gemm(10.0, &mat2, &mat3, 5.0);
+    /// assert_relative_eq!(mat1, expected);
+    /// ```
     #[inline]
     pub fn gemm<R2: Dim, C2: Dim, R3: Dim, C3: Dim, SB, SC>(
         &mut self,
@@ -680,6 +756,25 @@ where
     /// `alpha` and `beta` are scalar.
     ///
     /// If `beta` is zero, `self` is never read.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # extern crate nalgebra;
+    /// # use nalgebra::{Matrix3x2, Matrix3x4, Matrix2x4};
+    /// let mut mat1 = Matrix2x4::identity();
+    /// let mat2 = Matrix3x2::new(1.0, 4.0,
+    ///                           2.0, 5.0,
+    ///                           3.0, 6.0);
+    /// let mat3 = Matrix3x4::new(0.1, 0.2, 0.3, 0.4,
+    ///                           0.5, 0.6, 0.7, 0.8,
+    ///                           0.9, 1.0, 1.1, 1.2);
+    /// let expected = mat2.transpose() * mat3 * 10.0 + mat1 * 5.0;
+    ///
+    /// mat1.gemm_tr(10.0, &mat2, &mat3, 5.0);
+    /// assert_relative_eq!(mat1, expected);
+    /// ```
     #[inline]
     pub fn gemm_tr<R2: Dim, C2: Dim, R3: Dim, C3: Dim, SB, SC>(
         &mut self,
@@ -725,6 +820,20 @@ where
     ///
     /// If `beta` is zero, `self` is never read. The result is symmetric. Only the lower-triangular
     /// (including the diagonal) part of `self` is read/written.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::{Matrix2, Vector2};
+    /// let mut mat = Matrix2::identity();
+    /// let vec1 = Vector2::new(1.0, 2.0);
+    /// let vec2 = Vector2::new(0.1, 0.2);
+    /// let expected = vec1 * vec2.transpose() * 10.0 + mat * 5.0;
+    /// mat.m12 = 99999.99999; // This component is on the upper-triangular part and will not be read/written.
+    ///
+    /// mat.ger_symm(10.0, &vec1, &vec2, 5.0);
+    /// assert_eq!(mat.lower_triangle(), expected.lower_triangle());
+    /// assert_eq!(mat.m12, 99999.99999); // This was untouched.
     #[inline]
     pub fn ger_symm<D2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -768,6 +877,30 @@ where
     /// Computes the quadratic form `self = alpha * lhs * mid * lhs.transpose() + beta * self`.
     ///
     /// This uses the provided workspace `work` to avoid allocations for intermediate results.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # extern crate nalgebra;
+    /// # use nalgebra::{DMatrix, DVector};
+    /// // Note that all those would also work with statically-sized matrices.
+    /// // We use DMatrix/DVector since that's the only case where pre-allocating the
+    /// // workspace is actually useful (assuming the same workspace is re-used for
+    /// // several computations) because it avoids repeated dynamic allocations.
+    /// let mut mat = DMatrix::identity(2, 2);
+    /// let lhs = DMatrix::from_row_slice(2, 3, &[1.0, 2.0, 3.0,
+    ///                                           4.0, 5.0, 6.0]);
+    /// let mid = DMatrix::from_row_slice(3, 3, &[0.1, 0.2, 0.3,
+    ///                                           0.5, 0.6, 0.7,
+    ///                                           0.9, 1.0, 1.1]);
+    /// // The random shows that values on the workspace do not
+    /// // matter as they will be overwritten.
+    /// let mut workspace = DVector::new_random(2);
+    /// let expected = &lhs * &mid * lhs.transpose() * 10.0 + &mat * 5.0;
+    ///
+    /// mat.quadform_tr_with_workspace(&mut workspace, 10.0, &lhs, &mid, 5.0);
+    /// assert_relative_eq!(mat, expected);
     pub fn quadform_tr_with_workspace<D2, S2, R3, C3, S3, D4, S4>(
         &mut self,
         work: &mut Vector<N, D2, S2>,
@@ -797,7 +930,25 @@ where
     /// Computes the quadratic form `self = alpha * lhs * mid * lhs.transpose() + beta * self`.
     ///
     /// This allocates a workspace vector of dimension D1 for intermediate results.
+    /// If `D1` is a type-level integer, then the allocation is performed on the stack.
     /// Use `.quadform_tr_with_workspace(...)` instead to avoid allocations.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # extern crate nalgebra;
+    /// # use nalgebra::{Matrix2, Matrix3, Matrix2x3, Vector2};
+    /// let mut mat = Matrix2::identity();
+    /// let lhs = Matrix2x3::new(1.0, 2.0, 3.0,
+    ///                          4.0, 5.0, 6.0);
+    /// let mid = Matrix3::new(0.1, 0.2, 0.3,
+    ///                        0.5, 0.6, 0.7,
+    ///                        0.9, 1.0, 1.1);
+    /// let expected = lhs * mid * lhs.transpose() * 10.0 + mat * 5.0;
+    ///
+    /// mat.quadform_tr(10.0, &lhs, &mid, 5.0);
+    /// assert_relative_eq!(mat, expected);
     pub fn quadform_tr<R3, C3, S3, D4, S4>(
         &mut self,
         alpha: N,
@@ -820,6 +971,29 @@ where
     /// Computes the quadratic form `self = alpha * rhs.transpose() * mid * rhs + beta * self`.
     ///
     /// This uses the provided workspace `work` to avoid allocations for intermediate results.
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # extern crate nalgebra;
+    /// # use nalgebra::{DMatrix, DVector};
+    /// // Note that all those would also work with statically-sized matrices.
+    /// // We use DMatrix/DVector since that's the only case where pre-allocating the
+    /// // workspace is actually useful (assuming the same workspace is re-used for
+    /// // several computations) because it avoids repeated dynamic allocations.
+    /// let mut mat = DMatrix::identity(2, 2);
+    /// let rhs = DMatrix::from_row_slice(3, 2, &[1.0, 2.0,
+    ///                                           3.0, 4.0,
+    ///                                           5.0, 6.0]);
+    /// let mid = DMatrix::from_row_slice(3, 3, &[0.1, 0.2, 0.3,
+    ///                                           0.5, 0.6, 0.7,
+    ///                                           0.9, 1.0, 1.1]);
+    /// // The random shows that values on the workspace do not
+    /// // matter as they will be overwritten.
+    /// let mut workspace = DVector::new_random(3);
+    /// let expected = rhs.transpose() * &mid * &rhs * 10.0 + &mat * 5.0;
+    ///
+    /// mat.quadform_with_workspace(&mut workspace, 10.0, &mid, &rhs, 5.0);
+    /// assert_relative_eq!(mat, expected);
     pub fn quadform_with_workspace<D2, S2, D3, S3, R4, C4, S4>(
         &mut self,
         work: &mut Vector<N, D2, S2>,
@@ -850,7 +1024,24 @@ where
     /// Computes the quadratic form `self = alpha * rhs.transpose() * mid * rhs + beta * self`.
     ///
     /// This allocates a workspace vector of dimension D2 for intermediate results.
+    /// If `D2` is a type-level integer, then the allocation is performed on the stack.
     /// Use `.quadform_with_workspace(...)` instead to avoid allocations.
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # extern crate nalgebra;
+    /// # use nalgebra::{Matrix2, Matrix3x2, Matrix3};
+    /// let mut mat = Matrix2::identity();
+    /// let rhs = Matrix3x2::new(1.0, 2.0,
+    ///                          3.0, 4.0,
+    ///                          5.0, 6.0);
+    /// let mid = Matrix3::new(0.1, 0.2, 0.3,
+    ///                        0.5, 0.6, 0.7,
+    ///                        0.9, 1.0, 1.1);
+    /// let expected = rhs.transpose() * mid * rhs * 10.0 + mat * 5.0;
+    ///
+    /// mat.quadform(10.0, &mid, &rhs, 5.0);
+    /// assert_relative_eq!(mat, expected);
     pub fn quadform<D2, S2, R3, C3, S3>(
         &mut self,
         alpha: N,

--- a/src/base/componentwise.rs
+++ b/src/base/componentwise.rs
@@ -120,7 +120,7 @@ macro_rules! component_binop_impl(
 
             #[doc = $desc_mut]
             #[inline]
-            #[deprecated(note = "This is renamed using the `_assign` sufix instead of the `_mut` suffix.")]
+            #[deprecated(note = "This is renamed using the `_assign` suffix instead of the `_mut` suffix.")]
             pub fn $binop_mut<R2, C2, SB>(&mut self, rhs: &Matrix<N, R2, C2, SB>)
                 where N: $Trait,
                       R2: Dim,

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -160,6 +160,13 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     }
 
     /// The total number of elements of this matrix.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Matrix3x4;
+    /// let mat = Matrix3x4::<f32>::zeros();
+    /// assert_eq!(mat.len(), 12);
     #[inline]
     pub fn len(&self) -> usize {
         let (nrows, ncols) = self.shape();
@@ -167,6 +174,13 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     }
 
     /// The shape of this matrix returned as the tuple (number of rows, number of columns).
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Matrix3x4;
+    /// let mat = Matrix3x4::<f32>::zeros();
+    /// assert_eq!(mat.shape(), (3, 4));
     #[inline]
     pub fn shape(&self) -> (usize, usize) {
         let (nrows, ncols) = self.data.shape();
@@ -174,25 +188,63 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     }
 
     /// The number of rows of this matrix.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Matrix3x4;
+    /// let mat = Matrix3x4::<f32>::zeros();
+    /// assert_eq!(mat.nrows(), 3);
     #[inline]
     pub fn nrows(&self) -> usize {
         self.shape().0
     }
 
     /// The number of columns of this matrix.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Matrix3x4;
+    /// let mat = Matrix3x4::<f32>::zeros();
+    /// assert_eq!(mat.ncols(), 4);
     #[inline]
     pub fn ncols(&self) -> usize {
         self.shape().1
     }
 
     /// The strides (row stride, column stride) of this matrix.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::DMatrix;
+    /// let mat = DMatrix::<f32>::zeros(10, 10);
+    /// let slice = mat.slice_with_steps((0, 0), (5, 3), (1, 2));
+    /// // The column strides is the number of steps (here 2) multiplied by the corresponding dimension.
+    /// assert_eq!(mat.strides(), (1, 10));
     #[inline]
     pub fn strides(&self) -> (usize, usize) {
         let (srows, scols) = self.data.strides();
         (srows.value(), scols.value())
     }
 
-    /// Iterates through this matrix coordinates.
+    /// Iterates through this matrix coordinates in column-major order.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::Matrix2x3;
+    /// let mat = Matrix2x3::new(11, 12, 13,
+    ///                          21, 22, 23);
+    /// let mut it = mat.iter();
+    /// assert_eq!(*it.next().unwrap(), 11);
+    /// assert_eq!(*it.next().unwrap(), 21);
+    /// assert_eq!(*it.next().unwrap(), 12);
+    /// assert_eq!(*it.next().unwrap(), 22);
+    /// assert_eq!(*it.next().unwrap(), 13);
+    /// assert_eq!(*it.next().unwrap(), 23);
+    /// assert!(it.next().is_none());
     #[inline]
     pub fn iter(&self) -> MatrixIter<N, R, C, S> {
         MatrixIter::new(&self.data)
@@ -363,7 +415,10 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// Returns a matrix containing the result of `f` applied to each of its entries. Unlike `map`,
     /// `f` also gets passed the row and column index, i.e. `f(value, row, col)`.
     #[inline]
-    pub fn map_with_location<N2: Scalar, F: FnMut(usize, usize, N) -> N2>(&self, mut f: F) -> MatrixMN<N2, R, C>
+    pub fn map_with_location<N2: Scalar, F: FnMut(usize, usize, N) -> N2>(
+        &self,
+        mut f: F,
+    ) -> MatrixMN<N2, R, C>
     where
         DefaultAllocator: Allocator<N2, R, C>,
     {
@@ -419,22 +474,28 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// Returns a matrix containing the result of `f` applied to each entries of `self` and
     /// `b`, and `c`.
     #[inline]
-    pub fn zip_zip_map<N2, N3, N4, S2, S3, F>(&self, b: &Matrix<N2, R, C, S2>, c: &Matrix<N3, R, C, S3>, mut f: F) -> MatrixMN<N4, R, C>
-        where
-            N2: Scalar,
-            N3: Scalar,
-            N4: Scalar,
-            S2: Storage<N2, R, C>,
-            S3: Storage<N3, R, C>,
-            F: FnMut(N, N2, N3) -> N4,
-            DefaultAllocator: Allocator<N4, R, C>,
+    pub fn zip_zip_map<N2, N3, N4, S2, S3, F>(
+        &self,
+        b: &Matrix<N2, R, C, S2>,
+        c: &Matrix<N3, R, C, S3>,
+        mut f: F,
+    ) -> MatrixMN<N4, R, C>
+    where
+        N2: Scalar,
+        N3: Scalar,
+        N4: Scalar,
+        S2: Storage<N2, R, C>,
+        S3: Storage<N3, R, C>,
+        F: FnMut(N, N2, N3) -> N4,
+        DefaultAllocator: Allocator<N4, R, C>,
     {
         let (nrows, ncols) = self.data.shape();
 
         let mut res = unsafe { MatrixMN::new_uninitialized_generic(nrows, ncols) };
 
         assert!(
-            (nrows.value(), ncols.value()) == b.shape() && (nrows.value(), ncols.value()) == c.shape(),
+            (nrows.value(), ncols.value()) == b.shape()
+                && (nrows.value(), ncols.value()) == c.shape(),
             "Matrix simultaneous traversal error: dimension mismatch."
         );
 
@@ -1274,20 +1335,32 @@ impl<N: Real, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
 
 impl<N: Real, D: Dim, S: Storage<N, D>> Unit<Vector<N, D, S>> {
     /// Computes the spherical linear interpolation between two unit vectors.
-    pub fn slerp<S2: Storage<N, D>>(&self, rhs: &Unit<Vector<N, D, S2>>, t: N) -> Unit<VectorN<N, D>>
-        where
-            DefaultAllocator: Allocator<N, D> {
+    pub fn slerp<S2: Storage<N, D>>(
+        &self,
+        rhs: &Unit<Vector<N, D, S2>>,
+        t: N,
+    ) -> Unit<VectorN<N, D>>
+    where
+        DefaultAllocator: Allocator<N, D>,
+    {
         // FIXME: the result is wrong when self and rhs are collinear with opposite direction.
-        self.try_slerp(rhs, t, N::default_epsilon()).unwrap_or(Unit::new_unchecked(self.clone_owned()))
+        self.try_slerp(rhs, t, N::default_epsilon())
+            .unwrap_or(Unit::new_unchecked(self.clone_owned()))
     }
 
     /// Computes the spherical linear interpolation between two unit vectors.
     ///
     /// Returns `None` if the two vectors are almost collinear and with opposite direction
     /// (in this case, there is an infinity of possible results).
-    pub fn try_slerp<S2: Storage<N, D>>(&self, rhs: &Unit<Vector<N, D, S2>>, t: N, epsilon: N) -> Option<Unit<VectorN<N, D>>>
+    pub fn try_slerp<S2: Storage<N, D>>(
+        &self,
+        rhs: &Unit<Vector<N, D, S2>>,
+        t: N,
+        epsilon: N,
+    ) -> Option<Unit<VectorN<N, D>>>
     where
-        DefaultAllocator: Allocator<N, D> {
+        DefaultAllocator: Allocator<N, D>,
+    {
         let c_hang = self.dot(rhs);
 
         // self == other


### PR DESCRIPTION
This is a first step toward adding doc-tests and "see also" sections for all methods on nalgebra, just like @waywardmonkeys started to do on nalgebra-glm.

This PR only deals with doc-tests on BLAS operations.