### PR TITLE
Fix MatrixMN::from_distribution

### DIFF
--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -251,7 +251,7 @@ where DefaultAllocator: Allocator<N, R, C>
     pub fn from_distribution_generic<Distr: Distribution<N> + ?Sized, G: Rng + ?Sized>(
         nrows: R,
         ncols: C,
-        distribution: &mut Distr,
+        distribution: &Distr,
         rng: &mut G,
     ) -> Self
     {
@@ -584,7 +584,7 @@ macro_rules! impl_constructors(
             #[inline]
             pub fn from_distribution<Distr: Distribution<N> + ?Sized, G: Rng + ?Sized>(
                 $($args: usize,)*
-                distribution: &mut Distr,
+                distribution: &Distr,
                 rng: &mut G,
             ) -> Self {
                 Self::from_distribution_generic($($gargs, )* distribution, rng)
@@ -721,7 +721,7 @@ where
         Unit::new_normalize(VectorN::from_distribution_generic(
             D::name(),
             U1,
-            &mut StandardNormal,
+            &StandardNormal,
             rng,
         ))
     }


### PR DESCRIPTION
`MatrixMN::from_distribution` does not require the use of `&mut Distribution`, while `&Distribution` is sufficient. For the moment, if we want, for example, to call the function in parallel, we have to either recreate the distribution or compose it with an `Arc<Mutex>`, which could be inefficient.

Here is a minimal code that reproduces the encountered error:

```rust
extern crate nalgebra as na;
extern crate rand;
extern crate rayon;

use na::Vector3;
use rand::distributions::StandardNormal;
use rayon::prelude::*;

fn main() {
    let mut noise = StandardNormal;
    let mut forces = vec![Vector3::zeros(); 4];

    forces.par_iter_mut().for_each(|force| {
        let mut rng = rand::thread_rng();
        *force += Vector3::from_distribution(&mut noise, &mut rng);
        //                                        ^^^^^
        // [rustc] cannot borrow data mutably in a captured outer variable in an
        // `Fn` closure
    })
}
```

After the fix, this code becomes valid:

```rust
extern crate nalgebra as na;
extern crate rand;
extern crate rayon;

use na::Vector3;
use rand::distributions::StandardNormal;
use rayon::prelude::*;

fn main() {
    let noise = StandardNormal;
    let mut forces = vec![Vector3::zeros(); 4];

    forces.par_iter_mut().for_each(|force| {
        let mut rng = rand::thread_rng();
        *force += Vector3::from_distribution(&noise, &mut rng);
    })
}
```