### PR TITLE
Implement `Extend` for `Matrix`

### DIFF
--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -717,13 +717,12 @@ where
     ///
     /// # Example
     /// ```
-    /// use nalgebra::{Dynamic, Matrix, MatrixMN, Matrix3};
+    /// # use nalgebra::{DMatrix, Dynamic, Matrix, MatrixMN, Matrix3};
     ///
     /// let data = vec![0, 1, 2,      // column 1
     ///                 3, 4, 5];     // column 2
     ///
-    /// let mut matrix : MatrixMN<_, Dynamic, Dynamic> =
-    ///   Matrix::from_vec_generic(Dynamic::new(3), Dynamic::new(2), data);
+    /// let mut matrix = DMatrix::from_vec(3, 2, data);
     ///
     /// matrix.extend(vec![6, 7, 8]); // column 3
     ///
@@ -738,14 +737,14 @@ where
     /// `Matrix`.
     ///
     /// ```should_panic
-    /// # use nalgebra::{Dynamic, Matrix, MatrixMN, Matrix3, U3};
+    /// # use nalgebra::{DMatrix, Dynamic, MatrixMN};
     /// let data = vec![0, 1, 2,  // column 1
     ///                 3, 4, 5]; // column 2
     ///
-    /// let mut matrix : MatrixMN<_, U3, Dynamic> =
-    ///   Matrix::from_vec_generic(U3, Dynamic::new(2), data);
+    /// let mut matrix = DMatrix::from_vec(3, 2, data);
     ///
-    /// matrix.extend(vec![6, 7, 8, 9]); // column 3
+    /// // The following panics because the vec length is not a multiple of 3.
+    /// matrix.extend(vec![6, 7, 8, 9]);
     /// ```
     fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I) {
         self.data.extend(iter);
@@ -764,7 +763,7 @@ where
     ///
     /// # Example
     /// ```
-    /// use nalgebra::DVector;
+    /// # use nalgebra::DVector;
     /// let mut vector = DVector::from_vec(3, vec![0, 1, 2]);
     /// vector.extend(vec![3, 4, 5]);
     /// assert!(vector.eq(&DVector::from_vec(6, vec![0, 1, 2, 3, 4, 5])));

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -779,7 +779,8 @@ where
     R: Dim,
     S: Extend<Vector<N, RV, SV>>,
     RV: Dim,
-    SV: Storage<N, RV>
+    SV: Storage<N, RV>,
+    ShapeConstraint: SameNumberOfRows<R, RV>,
 {
     /// Extends the number of columns of a `Matrix` with `Vector`s
     /// from a given iterator.

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -772,3 +772,66 @@ where
         self.data.extend(iter);
     }
 }
+
+impl<N, R, S, RV, SV> Extend<Vector<N, RV, SV>> for Matrix<N, R, Dynamic, S>
+where
+    N: Scalar,
+    R: Dim,
+    S: Extend<Vector<N, RV, SV>>,
+    RV: Dim,
+    SV: Storage<N, RV>
+{
+    /// Extends the number of columns of a `Matrix` with `Vector`s
+    /// from a given iterator.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::{DMatrix, Vector3, Matrix3x4};
+    ///
+    /// let data = vec![0, 1, 2,          // column 1
+    ///                 3, 4, 5];         // column 2
+    ///
+    /// let mut matrix = DMatrix::from_vec(3, 2, data);
+    ///
+    /// matrix.extend(
+    ///   vec![Vector3::new(6,  7,  8),   // column 3
+    ///        Vector3::new(9, 10, 11)]); // column 4
+    ///
+    /// assert!(matrix.eq(&Matrix3x4::new(0, 3, 6,  9,
+    ///                                   1, 4, 7, 10,
+    ///                                   2, 5, 8, 11)));
+    /// ```
+    ///
+    /// # Panics
+    /// This function panics if the dimension of each `Vector` yielded
+    /// by the given iterator is not equal to the number of rows of
+    /// this `Matrix`.
+    ///
+    /// ```should_panic
+    /// # use nalgebra::{DMatrix, Vector2, Matrix3x4};
+    /// let mut matrix =
+    ///   DMatrix::from_vec(3, 2,
+    ///                     vec![0, 1, 2,   // column 1
+    ///                          3, 4, 5]); // column 2
+    ///
+    /// // The following panics because this matrix can only be extended with 3-dimensional vectors.
+    /// matrix.extend(
+    ///   vec![Vector2::new(6,  7)]); // too few dimensions!
+    /// ```
+    ///
+    /// ```should_panic
+    /// # use nalgebra::{DMatrix, Vector4, Matrix3x4};
+    /// let mut matrix =
+    ///   DMatrix::from_vec(3, 2,
+    ///                     vec![0, 1, 2,   // column 1
+    ///                          3, 4, 5]); // column 2
+    ///
+    /// // The following panics because this matrix can only be extended with 3-dimensional vectors.
+    /// matrix.extend(
+    ///   vec![Vector4::new(6, 7, 8, 9)]); // too few dimensions!
+    /// ```
+    fn extend<I: IntoIterator<Item=Vector<N, RV, SV>>>(&mut self, iter: I)
+    {
+        self.data.extend(iter);
+    }
+}

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -703,3 +703,51 @@ unsafe fn extend_rows<N: Scalar>(
         );
     }
 }
+
+/// Extend the number of columns of the `Matrix` with elements from
+/// a given iterator.
+impl<N, R, S> Extend<N> for Matrix<N, R, Dynamic, S>
+where
+    N: Scalar,
+    R: Dim,
+    S: Extend<N>,
+{
+    /// Extend the number of columns of the `Matrix` with elements
+    /// from the given iterator.
+    ///
+    /// # Example
+    /// ```
+    /// use nalgebra::{Dynamic, Matrix, MatrixMN, Matrix3};
+    ///
+    /// let data = vec![0, 1, 2,      // column 1
+    ///                 3, 4, 5];     // column 2
+    ///
+    /// let mut matrix : MatrixMN<_, Dynamic, Dynamic> =
+    ///   Matrix::from_vec_generic(Dynamic::new(3), Dynamic::new(2), data);
+    ///
+    /// matrix.extend(vec![6, 7, 8]); // column 3
+    ///
+    /// assert!(matrix.eq(&Matrix3::new(0, 3, 6,
+    ///                                 1, 4, 7,
+    ///                                 2, 5, 8)));
+    /// ```
+    ///
+    /// # Panics
+    /// This function panics if the number of elements yielded by the
+    /// given iterator is not a multiple of the number of rows of the
+    /// `Matrix`.
+    ///
+    /// ```should_panic
+    /// # use nalgebra::{Dynamic, Matrix, MatrixMN, Matrix3, U3};
+    /// let data = vec![0, 1, 2,  // column 1
+    ///                 3, 4, 5]; // column 2
+    ///
+    /// let mut matrix : MatrixMN<_, U3, Dynamic> =
+    ///   Matrix::from_vec_generic(U3, Dynamic::new(2), data);
+    ///
+    /// matrix.extend(vec![6, 7, 8, 9]); // column 3
+    /// ```
+    fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I) {
+        self.data.extend(iter);
+    }
+}

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -751,3 +751,25 @@ where
         self.data.extend(iter);
     }
 }
+
+/// Extend the number of rows of the `Vector` with elements from
+/// a given iterator.
+impl<N, S> Extend<N> for Matrix<N, Dynamic, U1, S>
+where
+    N: Scalar,
+    S: Extend<N>,
+{
+    /// Extend the number of rows of a `Vector` with elements
+    /// from the given iterator.
+    ///
+    /// # Example
+    /// ```
+    /// use nalgebra::DVector;
+    /// let mut vector = DVector::from_vec(3, vec![0, 1, 2]);
+    /// vector.extend(vec![3, 4, 5]);
+    /// assert!(vector.eq(&DVector::from_vec(6, vec![0, 1, 2, 3, 4, 5])));
+    /// ```
+    fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I) {
+        self.data.extend(iter);
+    }
+}

--- a/src/base/matrix_vec.rs
+++ b/src/base/matrix_vec.rs
@@ -10,6 +10,7 @@ use base::default_allocator::DefaultAllocator;
 use base::dimension::{Dim, DimName, Dynamic, U1};
 use base::storage::{ContiguousStorage, ContiguousStorageMut, Owned, Storage, StorageMut};
 use base::{Scalar, Vector};
+use base::constraint::{SameNumberOfRows, ShapeConstraint};
 
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
@@ -264,7 +265,8 @@ where
     N: Scalar,
     R: Dim,
     RV: Dim,
-    SV: Storage<N, RV>
+    SV: Storage<N, RV>,
+    ShapeConstraint: SameNumberOfRows<R, RV>,
 {
     /// Extends the number of columns of the `MatrixVec` with vectors
     /// from the given iterator.

--- a/src/base/matrix_vec.rs
+++ b/src/base/matrix_vec.rs
@@ -258,3 +258,14 @@ impl<N, R: Dim> Extend<N> for MatrixVec<N, R, Dynamic>
           "The number of elements produced by the given iterator was not a multiple of the number of rows.");
     }
 }
+
+impl<N> Extend<N> for MatrixVec<N, Dynamic, U1>
+{
+    /// Extends the number of rows of the `MatrixVec` with elements
+    /// from the given iterator.
+    fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I)
+    {
+        self.data.extend(iter);
+        self.nrows = Dynamic::new(self.data.len());
+    }
+}

--- a/src/base/matrix_vec.rs
+++ b/src/base/matrix_vec.rs
@@ -240,3 +240,21 @@ unsafe impl<N: Scalar, R: DimName> ContiguousStorage<N, R, Dynamic> for MatrixVe
 
 unsafe impl<N: Scalar, R: DimName> ContiguousStorageMut<N, R, Dynamic> for MatrixVec<N, R, Dynamic> where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
 {}
+
+impl<N, R: Dim> Extend<N> for MatrixVec<N, R, Dynamic>
+{
+    /// Extends the number of columns of the `MatrixVec` with elements
+    /// from the given iterator.
+    ///
+    /// # Panics
+    /// This function panics if the number of elements yielded by the
+    /// given iterator is not a multiple of the number of rows of the
+    /// `MatrixVec`.
+    fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I)
+    {
+        self.data.extend(iter);
+        self.ncols = Dynamic::new(self.data.len() / self.nrows.value());
+        assert!(self.data.len() % self.nrows.value() == 0,
+          "The number of elements produced by the given iterator was not a multiple of the number of rows.");
+    }
+}


### PR DESCRIPTION
My hope is that this is a step towards making concatenating vectors a little more ergonomic (see #446).

This PR is of narrow scope. `Extend` is only implemented for cases in which the operation is cheap. Right now this means:
 - extend a matrix with new columns populated from an iterator
 - extend a vector with new rows populated from an iterator
