### PR TITLE
RFC: to_homogeneous for MatrixN

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -20,7 +20,7 @@ use alga::general::{ClosedAdd, ClosedMul, ClosedSub, Real, Ring};
 
 use base::allocator::{Allocator, SameShapeAllocator, SameShapeC, SameShapeR};
 use base::constraint::{DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
-use base::dimension::{Dim, DimNameAdd, DimAdd, DimNameSum, DimSum, IsNotStaticOne, U1, U2, U3};
+use base::dimension::{Dim, DimAdd, DimSum, IsNotStaticOne, U1, U2, U3};
 use base::iter::{MatrixIter, MatrixIterMut};
 use base::storage::{
     ContiguousStorage, ContiguousStorageMut, Owned, SameShapeStorage, Storage, StorageMut,
@@ -830,15 +830,17 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
     }
 }
 
-impl<N: Scalar + One, D: DimNameAdd<U1> + IsNotStaticOne> MatrixN<N, D> {
+impl<N: Scalar + One + Zero, D: Dim + DimAdd<U1> + IsNotStaticOne, S: Storage<N, D, D>> Matrix<N, D, D, S> {
 
     /// Yields the homogeneous matrix for this matrix, i.e., appending an additional dimension and
     /// and setting the diagonal element to `1`.
     #[inline]
-    pub fn to_homogeneous(&self) -> MatrixN<N, DimNameSum<D, U1>>
-    where DefaultAllocator: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1>> {
-        let mut res = MatrixN::<N, DimNameSum<D, U1>>::identity();
-        res.fixed_slice_mut::<D, D>(0, 0).copy_from(&self);
+    pub fn to_homogeneous(&self) -> MatrixN<N, DimSum<D, U1>>
+    where DefaultAllocator: Allocator<N, DimSum<D, U1>, DimSum<D, U1>> {
+        assert!(self.is_square(), "Only square matrices can currently be transformed to homogeneous coordinates.");
+        let dim = DimSum::<D, U1>::from_usize(self.nrows() + 1);
+        let mut res = MatrixN::identity_generic(dim, dim); 
+        res.generic_slice_mut::<D, D>((0, 0), self.data.shape()).copy_from(&self);
         res
     }
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -20,7 +20,7 @@ use alga::general::{ClosedAdd, ClosedMul, ClosedSub, Real, Ring};
 
 use base::allocator::{Allocator, SameShapeAllocator, SameShapeC, SameShapeR};
 use base::constraint::{DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
-use base::dimension::{Dim, DimAdd, DimSum, U1, U2, U3};
+use base::dimension::{Dim, DimNameAdd, DimAdd, DimNameSum, DimSum, IsNotStaticOne, U1, U2, U3};
 use base::iter::{MatrixIter, MatrixIterMut};
 use base::storage::{
     ContiguousStorage, ContiguousStorageMut, Owned, SameShapeStorage, Storage, StorageMut,
@@ -828,6 +828,20 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
 
         res
     }
+}
+
+impl<N: Scalar + One, D: DimNameAdd<U1> + IsNotStaticOne> MatrixN<N, D> {
+
+    /// Yields the homogeneous matrix for this matrix, i.e., appending an additional dimension and
+    /// and setting the diagonal element to `1`.
+    #[inline]
+    pub fn to_homogeneous(&self) -> MatrixN<N, DimNameSum<D, U1>>
+    where DefaultAllocator: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1>> {
+        let mut res = MatrixN::<N, DimNameSum<D, U1>>::identity();
+        res.fixed_slice_mut::<D, D>(0, 0).copy_from(&self);
+        res
+    }
+
 }
 
 impl<N: Scalar + Zero, D: DimAdd<U1>, S: Storage<N, D>> Vector<N, D, S> {

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -830,7 +830,7 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
     }
 }
 
-impl<N: Scalar + One + Zero, D: Dim + DimAdd<U1> + IsNotStaticOne, S: Storage<N, D, D>> Matrix<N, D, D, S> {
+impl<N: Scalar + One + Zero, D: DimAdd<U1> + IsNotStaticOne, S: Storage<N, D, D>> Matrix<N, D, D, S> {
 
     /// Yields the homogeneous matrix for this matrix, i.e., appending an additional dimension and
     /// and setting the diagonal element to `1`.

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -201,6 +201,9 @@ where DefaultAllocator: Allocator<N, D, D>
         D: DimNameAdd<U1>,
         DefaultAllocator: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1>>,
     {
+        // We could use `MatrixN::to_homogeneous()` here, but that would imply
+        // adding the additional traits `DimAdd` and `IsNotStaticOne`. Maybe
+        // these things will get nicer once specialization lands in Rust.
         let mut res = MatrixN::<N, DimNameSum<D, U1>>::identity();
         res.fixed_slice_mut::<D, D>(0, 0).copy_from(&self.matrix);
 

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -278,7 +278,7 @@ fn to_homogeneous() {
     let c = Matrix2::new(1.0, 2.0, 3.0, 4.0);
     let expected_c = Matrix3::new(1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 1.0);
 
-    let d = DMatrix::from_row_slice(2, &[1.0, 2.0, 3.0, 4.0]);
+    let d = DMatrix::from_row_slice(2, 2, &[1.0, 2.0, 3.0, 4.0]);
     let expected_d = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 1.0]);
 
     assert_eq!(a.to_homogeneous(), expected_a);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -275,8 +275,16 @@ fn to_homogeneous() {
     let b = DVector::from_row_slice(3, &[1.0, 2.0, 3.0]);
     let expected_b = DVector::from_row_slice(4, &[1.0, 2.0, 3.0, 0.0]);
 
+    let c = Matrix2::new(1.0, 2.0, 3.0, 4.0);
+    let expected_c = Matrix3::new(1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 1.0);
+
+    let d = DMatrix::from_row_slice(2, &[1.0, 2.0, 3.0, 4.0]);
+    let expected_d = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 1.0]);
+
     assert_eq!(a.to_homogeneous(), expected_a);
     assert_eq!(b.to_homogeneous(), expected_b);
+    assert_eq!(c.to_homogeneous(), expected_c);
+    assert_eq!(d.to_homogeneous(), expected_d);
 }
 
 #[test]


### PR DESCRIPTION
First attempt at #471. It seems that the disambiguation using `IsNotStaticOne` is working, but I can't get it to compile. 

Currently, I get the following error message:

```
error[E0277]: cannot multiply `<D as base::dimension::DimName>::Value` to `<D as base::dimension::DimName>::Value`
   --> src/base/matrix.rs:833:1
    |
833 | / impl<N: Scalar + One, D: DimNameAdd<U1> + IsNotStaticOne> MatrixN<N, D> {
834 | |
835 | |     /// Yields the homogeneous matrix for this matrix, i.e., appending an additional dimension and
836 | |     /// and setting the diagonal element to `1`.
...   |
844 | |
845 | | }
    | |_^ no implementation for `<D as base::dimension::DimName>::Value * <D as base::dimension::DimName>::Value`
    |
    = help: the trait `std::ops::Mul` is not implemented for `<D as base::dimension::DimName>::Value`
    = help: consider adding a `where <D as base::dimension::DimName>::Value: std::ops::Mul` bound
    = note: required because of the requirements on the impl of `base::allocator::Allocator<N, D, D>` for `base::default_allocator::DefaultAllocator`
```

I think this has to do with how the `Allocator` is set up, but I can't get it to work.