### PR TITLE
Implement `Into<Vec<N>>` for `MatrixVec<N, R, C>`

### DIFF
--- a/src/base/matrix_vec.rs
+++ b/src/base/matrix_vec.rs
@@ -88,6 +88,13 @@ impl<N, R: Dim, C: Dim> Deref for MatrixVec<N, R, C> {
     }
 }
 
+impl<N, R: Dim, C: Dim> Into<Vec<N>> for MatrixVec<N, R, C>
+{
+    fn into(self) -> Vec<N> {
+        self.data
+    }
+}
+
 /*
  *
  * Dynamic − Static


### PR DESCRIPTION
Very narrowly addresses @jturner314's [proximate issue](https://github.com/rustsim/nalgebra/issues/473#issuecomment-440038489) of getting the `Vec` out of a `Matrix` backed by a `Vec`.

This makes possible something that was previously impossible. However, this change isn't enough on it's own to achieve the ergonomic goals of #479.



