### PR TITLE
Group swizzle methods by dimensional requirement.

### DIFF
--- a/src/base/swizzle.rs
+++ b/src/base/swizzle.rs
@@ -3,64 +3,60 @@ use storage::Storage;
 use typenum::{self, Cmp, Greater};
 
 macro_rules! impl_swizzle {
-    ($(where $BaseDim: ident: $name: ident() -> $Result: ident[$($i: expr),*]);*) => {
+    ($( where $BaseDim: ident: $( $name: ident() -> $Result: ident[$($i: expr),+] ),+ ;)* ) => {
         $(
-            impl<N: Scalar, D: DimName, S: Storage<N, D>> Vector<N, D, S> {
-                /// Builds a new vector from components of `self`.
-                #[inline]
-                pub fn $name(&self) -> $Result<N>
-                    where D::Value: Cmp<typenum::$BaseDim, Output=Greater> {
-                    $Result::new($(self[$i]),*)
-                }
+            impl<N: Scalar, D: DimName, S: Storage<N, D>> Vector<N, D, S>
+            where D::Value: Cmp<typenum::$BaseDim, Output=Greater>
+            {
+                $(
+                    /// Builds a new vector from components of `self`.
+                    #[inline]
+                    pub fn $name(&self) -> $Result<N> {
+                        $Result::new($(self[$i]),*)
+                    }
+                )*
             }
         )*
     }
 }
 
 impl_swizzle!(
-    where U0: xx() -> Vector2[0, 0];
-    where U1: xy() -> Vector2[0, 1];
-    where U2: xz() -> Vector2[0, 2];
-    where U1: yx() -> Vector2[1, 0];
-    where U1: yy() -> Vector2[1, 1];
-    where U2: yz() -> Vector2[1, 2];
-    where U2: zx() -> Vector2[2, 0];
-    where U2: zy() -> Vector2[2, 1];
-    where U2: zz() -> Vector2[2, 2];
+    where U0: xx()  -> Vector2[0, 0],
+              xxx() -> Vector3[0, 0, 0];
 
-    where U0: xxx() -> Vector3[0, 0, 0];
-    where U1: xxy() -> Vector3[0, 0, 1];
-    where U2: xxz() -> Vector3[0, 0, 2];
+    where U1: xy()  -> Vector2[0, 1],
+              yx()  -> Vector2[1, 0],
+              yy()  -> Vector2[1, 1],
+              xxy() -> Vector3[0, 0, 1],
+              xyx() -> Vector3[0, 1, 0],
+              xyy() -> Vector3[0, 1, 1],
+              yxx() -> Vector3[1, 0, 0],
+              yxy() -> Vector3[1, 0, 1],
+              yyx() -> Vector3[1, 1, 0],
+              yyy() -> Vector3[1, 1, 1];
 
-    where U1: xyx() -> Vector3[0, 1, 0];
-    where U1: xyy() -> Vector3[0, 1, 1];
-    where U2: xyz() -> Vector3[0, 1, 2];
-
-    where U2: xzx() -> Vector3[0, 2, 0];
-    where U2: xzy() -> Vector3[0, 2, 1];
-    where U2: xzz() -> Vector3[0, 2, 2];
-
-    where U1: yxx() -> Vector3[1, 0, 0];
-    where U1: yxy() -> Vector3[1, 0, 1];
-    where U2: yxz() -> Vector3[1, 0, 2];
-
-    where U1: yyx() -> Vector3[1, 1, 0];
-    where U1: yyy() -> Vector3[1, 1, 1];
-    where U2: yyz() -> Vector3[1, 1, 2];
-
-    where U2: yzx() -> Vector3[1, 2, 0];
-    where U2: yzy() -> Vector3[1, 2, 1];
-    where U2: yzz() -> Vector3[1, 2, 2];
-
-    where U2: zxx() -> Vector3[2, 0, 0];
-    where U2: zxy() -> Vector3[2, 0, 1];
-    where U2: zxz() -> Vector3[2, 0, 2];
-
-    where U2: zyx() -> Vector3[2, 1, 0];
-    where U2: zyy() -> Vector3[2, 1, 1];
-    where U2: zyz() -> Vector3[2, 1, 2];
-
-    where U2: zzx() -> Vector3[2, 2, 0];
-    where U2: zzy() -> Vector3[2, 2, 1];
-    where U2: zzz() -> Vector3[2, 2, 2]
+    where U2: xz()  -> Vector2[0, 2],
+              yz()  -> Vector2[1, 2],
+              zx()  -> Vector2[2, 0],
+              zy()  -> Vector2[2, 1],
+              zz()  -> Vector2[2, 2],
+              xxz() -> Vector3[0, 0, 2],
+              xyz() -> Vector3[0, 1, 2],
+              xzx() -> Vector3[0, 2, 0],
+              xzy() -> Vector3[0, 2, 1],
+              xzz() -> Vector3[0, 2, 2],
+              yxz() -> Vector3[1, 0, 2],
+              yyz() -> Vector3[1, 1, 2],
+              yzx() -> Vector3[1, 2, 0],
+              yzy() -> Vector3[1, 2, 1],
+              yzz() -> Vector3[1, 2, 2],
+              zxx() -> Vector3[2, 0, 0],
+              zxy() -> Vector3[2, 0, 1],
+              zxz() -> Vector3[2, 0, 2],
+              zyx() -> Vector3[2, 1, 0],
+              zyy() -> Vector3[2, 1, 1],
+              zyz() -> Vector3[2, 1, 2],
+              zzx() -> Vector3[2, 2, 0],
+              zzy() -> Vector3[2, 2, 1],
+              zzz() -> Vector3[2, 2, 2];
 );

--- a/src/geometry/swizzle.rs
+++ b/src/geometry/swizzle.rs
@@ -4,66 +4,62 @@ use geometry::{Point, Point2, Point3};
 use typenum::{self, Cmp, Greater};
 
 macro_rules! impl_swizzle {
-    ($(where $BaseDim: ident: $name: ident() -> $Result: ident[$($i: expr),*]);*) => {
+    ($( where $BaseDim: ident: $( $name: ident() -> $Result: ident[$($i: expr),+] ),+ ;)* ) => {
         $(
             impl<N: Scalar, D: DimName> Point<N, D>
-            where DefaultAllocator: Allocator<N, D>
+            where
+                DefaultAllocator: Allocator<N, D>,
+                D::Value: Cmp<typenum::$BaseDim, Output=Greater>
             {
-                /// Builds a new vector from components of `self`.
-                #[inline]
-                pub fn $name(&self) -> $Result<N>
-                    where D::Value: Cmp<typenum::$BaseDim, Output=Greater> {
-                    $Result::new($(self[$i]),*)
-                }
+                $(
+                    /// Builds a new point from components of `self`.
+                    #[inline]
+                    pub fn $name(&self) -> $Result<N> {
+                        $Result::new($(self[$i]),*)
+                    }
+                )*
             }
         )*
     }
 }
 
 impl_swizzle!(
-    where U0: xx() -> Point2[0, 0];
-    where U1: xy() -> Point2[0, 1];
-    where U2: xz() -> Point2[0, 2];
-    where U1: yx() -> Point2[1, 0];
-    where U1: yy() -> Point2[1, 1];
-    where U2: yz() -> Point2[1, 2];
-    where U2: zx() -> Point2[2, 0];
-    where U2: zy() -> Point2[2, 1];
-    where U2: zz() -> Point2[2, 2];
+    where U0: xx()  -> Point2[0, 0],
+              xxx() -> Point3[0, 0, 0];
 
-    where U0: xxx() -> Point3[0, 0, 0];
-    where U1: xxy() -> Point3[0, 0, 1];
-    where U2: xxz() -> Point3[0, 0, 2];
+    where U1: xy()  -> Point2[0, 1],
+              yx()  -> Point2[1, 0],
+              yy()  -> Point2[1, 1],
+              xxy() -> Point3[0, 0, 1],
+              xyx() -> Point3[0, 1, 0],
+              xyy() -> Point3[0, 1, 1],
+              yxx() -> Point3[1, 0, 0],
+              yxy() -> Point3[1, 0, 1],
+              yyx() -> Point3[1, 1, 0],
+              yyy() -> Point3[1, 1, 1];
 
-    where U1: xyx() -> Point3[0, 1, 0];
-    where U1: xyy() -> Point3[0, 1, 1];
-    where U2: xyz() -> Point3[0, 1, 2];
-
-    where U2: xzx() -> Point3[0, 2, 0];
-    where U2: xzy() -> Point3[0, 2, 1];
-    where U2: xzz() -> Point3[0, 2, 2];
-
-    where U1: yxx() -> Point3[1, 0, 0];
-    where U1: yxy() -> Point3[1, 0, 1];
-    where U2: yxz() -> Point3[1, 0, 2];
-
-    where U1: yyx() -> Point3[1, 1, 0];
-    where U1: yyy() -> Point3[1, 1, 1];
-    where U2: yyz() -> Point3[1, 1, 2];
-
-    where U2: yzx() -> Point3[1, 2, 0];
-    where U2: yzy() -> Point3[1, 2, 1];
-    where U2: yzz() -> Point3[1, 2, 2];
-
-    where U2: zxx() -> Point3[2, 0, 0];
-    where U2: zxy() -> Point3[2, 0, 1];
-    where U2: zxz() -> Point3[2, 0, 2];
-
-    where U2: zyx() -> Point3[2, 1, 0];
-    where U2: zyy() -> Point3[2, 1, 1];
-    where U2: zyz() -> Point3[2, 1, 2];
-
-    where U2: zzx() -> Point3[2, 2, 0];
-    where U2: zzy() -> Point3[2, 2, 1];
-    where U2: zzz() -> Point3[2, 2, 2]
+    where U2: xz()  -> Point2[0, 2],
+              yz()  -> Point2[1, 2],
+              zx()  -> Point2[2, 0],
+              zy()  -> Point2[2, 1],
+              zz()  -> Point2[2, 2],
+              xxz() -> Point3[0, 0, 2],
+              xyz() -> Point3[0, 1, 2],
+              xzx() -> Point3[0, 2, 0],
+              xzy() -> Point3[0, 2, 1],
+              xzz() -> Point3[0, 2, 2],
+              yxz() -> Point3[1, 0, 2],
+              yyz() -> Point3[1, 1, 2],
+              yzx() -> Point3[1, 2, 0],
+              yzy() -> Point3[1, 2, 1],
+              yzz() -> Point3[1, 2, 2],
+              zxx() -> Point3[2, 0, 0],
+              zxy() -> Point3[2, 0, 1],
+              zxz() -> Point3[2, 0, 2],
+              zyx() -> Point3[2, 1, 0],
+              zyy() -> Point3[2, 1, 1],
+              zyz() -> Point3[2, 1, 2],
+              zzx() -> Point3[2, 2, 0],
+              zzy() -> Point3[2, 2, 1],
+              zzz() -> Point3[2, 2, 2];
 );


### PR DESCRIPTION
This is semantically equivalent, but improves the rendered documentation.

Previously, each swizzle method was contained in its own `impl`.