### PR TITLE
Remove copy requirement from Scalar trait

### DIFF
--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -13,6 +13,8 @@ use base::dimension::{Dim, Dynamic, U1, U2, U3, U4};
 use base::storage::{Storage, StorageMut};
 use base::{DefaultAllocator, Matrix, Scalar, SquareMatrix, Vector};
 
+
+
 impl<N: Scalar + PartialOrd + Signed, D: Dim, S: Storage<N, D>> Vector<N, D, S> {
     /// Computes the index of the vector component with the largest value.
     ///
@@ -197,27 +199,27 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
         // because the `for` loop below won't be very efficient on those.
         if (R::is::<U2>() || R2::is::<U2>()) && (C::is::<U1>() || C2::is::<U1>()) {
             unsafe {
-                let a = *self.get_unchecked(0, 0) * *rhs.get_unchecked(0, 0);
-                let b = *self.get_unchecked(1, 0) * *rhs.get_unchecked(1, 0);
+                let a = o!(self.get_unchecked(0, 0)) * o!(rhs.get_unchecked(0, 0));
+                let b = o!(self.get_unchecked(1, 0)) * o!(rhs.get_unchecked(1, 0));
 
                 return a + b;
             }
         }
         if (R::is::<U3>() || R2::is::<U3>()) && (C::is::<U1>() || C2::is::<U1>()) {
             unsafe {
-                let a = *self.get_unchecked(0, 0) * *rhs.get_unchecked(0, 0);
-                let b = *self.get_unchecked(1, 0) * *rhs.get_unchecked(1, 0);
-                let c = *self.get_unchecked(2, 0) * *rhs.get_unchecked(2, 0);
+                let a = o!(self.get_unchecked(0, 0)) * o!(rhs.get_unchecked(0, 0));
+                let b = o!(self.get_unchecked(1, 0)) * o!(rhs.get_unchecked(1, 0));
+                let c = o!(self.get_unchecked(2, 0)) * o!(rhs.get_unchecked(2, 0));
 
                 return a + b + c;
             }
         }
         if (R::is::<U4>() || R2::is::<U4>()) && (C::is::<U1>() || C2::is::<U1>()) {
             unsafe {
-                let mut a = *self.get_unchecked(0, 0) * *rhs.get_unchecked(0, 0);
-                let mut b = *self.get_unchecked(1, 0) * *rhs.get_unchecked(1, 0);
-                let c = *self.get_unchecked(2, 0) * *rhs.get_unchecked(2, 0);
-                let d = *self.get_unchecked(3, 0) * *rhs.get_unchecked(3, 0);
+                let mut a = o!(self.get_unchecked(0, 0)) * o!(rhs.get_unchecked(0, 0));
+                let mut b = o!(self.get_unchecked(1, 0)) * o!(rhs.get_unchecked(1, 0));
+                let c = o!(self.get_unchecked(2, 0)) * o!(rhs.get_unchecked(2, 0));
+                let d = o!(self.get_unchecked(3, 0)) * o!(rhs.get_unchecked(3, 0));
 
                 a += c;
                 b += d;
@@ -257,14 +259,14 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
             acc7 = N::zero();
 
             while self.nrows() - i >= 8 {
-                acc0 += unsafe { *self.get_unchecked(i + 0, j) * *rhs.get_unchecked(i + 0, j) };
-                acc1 += unsafe { *self.get_unchecked(i + 1, j) * *rhs.get_unchecked(i + 1, j) };
-                acc2 += unsafe { *self.get_unchecked(i + 2, j) * *rhs.get_unchecked(i + 2, j) };
-                acc3 += unsafe { *self.get_unchecked(i + 3, j) * *rhs.get_unchecked(i + 3, j) };
-                acc4 += unsafe { *self.get_unchecked(i + 4, j) * *rhs.get_unchecked(i + 4, j) };
-                acc5 += unsafe { *self.get_unchecked(i + 5, j) * *rhs.get_unchecked(i + 5, j) };
-                acc6 += unsafe { *self.get_unchecked(i + 6, j) * *rhs.get_unchecked(i + 6, j) };
-                acc7 += unsafe { *self.get_unchecked(i + 7, j) * *rhs.get_unchecked(i + 7, j) };
+                acc0 += unsafe { o!(self.get_unchecked(i + 0, j)) * o!(rhs.get_unchecked(i + 0, j)) };
+                acc1 += unsafe { o!(self.get_unchecked(i + 1, j)) * o!(rhs.get_unchecked(i + 1, j)) };
+                acc2 += unsafe { o!(self.get_unchecked(i + 2, j)) * o!(rhs.get_unchecked(i + 2, j)) };
+                acc3 += unsafe { o!(self.get_unchecked(i + 3, j)) * o!(rhs.get_unchecked(i + 3, j)) };
+                acc4 += unsafe { o!(self.get_unchecked(i + 4, j)) * o!(rhs.get_unchecked(i + 4, j)) };
+                acc5 += unsafe { o!(self.get_unchecked(i + 5, j)) * o!(rhs.get_unchecked(i + 5, j)) };
+                acc6 += unsafe { o!(self.get_unchecked(i + 6, j)) * o!(rhs.get_unchecked(i + 6, j)) };
+                acc7 += unsafe { o!(self.get_unchecked(i + 7, j)) * o!(rhs.get_unchecked(i + 7, j)) };
                 i += 8;
             }
 
@@ -274,7 +276,7 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
             res += acc3 + acc7;
 
             for k in i..self.nrows() {
-                res += unsafe { *self.get_unchecked(k, j) * *rhs.get_unchecked(k, j) }
+                res += unsafe { o!(self.get_unchecked(k, j)) * o!(rhs.get_unchecked(k, j)) }
             }
         }
 
@@ -314,7 +316,7 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
 
         for j in 0..self.nrows() {
             for i in 0..self.ncols() {
-                res += unsafe { *self.get_unchecked(j, i) * *rhs.get_unchecked(i, j) }
+                res += unsafe { o!(self.get_unchecked(j, i)) * o!(rhs.get_unchecked(i, j)) }
             }
         }
 
@@ -327,7 +329,7 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul {
     for i in 0..len {
         unsafe {
             let y = y.get_unchecked_mut(i * stride1);
-            *y = a * *x.get_unchecked(i * stride2) + beta * *y;
+            *y = c!(a) * o!(x.get_unchecked(i * stride2)) + c!(beta) * o!(y);
         }
     }
 }
@@ -336,7 +338,7 @@ fn array_ax<N>(y: &mut [N], a: N, x: &[N], stride1: usize, stride2: usize, len: 
 where N: Scalar + Zero + ClosedAdd + ClosedMul {
     for i in 0..len {
         unsafe {
-            *y.get_unchecked_mut(i * stride1) = a * *x.get_unchecked(i * stride2);
+            *y.get_unchecked_mut(i * stride1) = c!(a) * o!(x.get_unchecked(i * stride2));
         }
     }
 }
@@ -424,14 +426,14 @@ where
 
         // FIXME: avoid bound checks.
         let col2 = a.column(0);
-        let val = unsafe { *x.vget_unchecked(0) };
-        self.axpy(alpha * val, &col2, beta);
+        let val = unsafe { o!(x.vget_unchecked(0)) };
+        self.axpy(c!(alpha) * val, &col2, beta);
 
         for j in 1..ncols2 {
             let col2 = a.column(j);
-            let val = unsafe { *x.vget_unchecked(j) };
+            let val = unsafe { o!(x.vget_unchecked(j)) };
 
-            self.axpy(alpha * val, &col2, N::one());
+            self.axpy(c!(alpha) * val, &col2, N::one());
         }
     }
 
@@ -494,9 +496,9 @@ where
 
         // FIXME: avoid bound checks.
         let col2 = a.column(0);
-        let val = unsafe { *x.vget_unchecked(0) };
-        self.axpy(alpha * val, &col2, beta);
-        self[0] += alpha * x.rows_range(1..).dot(&a.slice_range(1.., 0));
+        let val = unsafe { o!(x.vget_unchecked(0)) };
+        self.axpy(c!(alpha) * val, &col2, beta);
+        self[0] += c!(alpha) * x.rows_range(1..).dot(&a.slice_range(1.., 0));
 
         for j in 1..dim2 {
             let col2 = a.column(j);
@@ -504,11 +506,11 @@ where
 
             let val;
             unsafe {
-                val = *x.vget_unchecked(j);
-                *self.vget_unchecked_mut(j) += alpha * dot;
+                val = o!(x.vget_unchecked(j));
+                *self.vget_unchecked_mut(j) += c!(alpha) * dot;
             }
             self.rows_range_mut(j + 1..)
-                .axpy(alpha * val, &col2.rows_range(j + 1..), N::one());
+                .axpy(c!(alpha) * val, &col2.rows_range(j + 1..), N::one());
         }
     }
 
@@ -559,12 +561,12 @@ where
         if beta.is_zero() {
             for j in 0..ncols2 {
                 let val = unsafe { self.vget_unchecked_mut(j) };
-                *val = alpha * a.column(j).dot(x)
+                *val = c!(alpha) * a.column(j).dot(x)
             }
         } else {
             for j in 0..ncols2 {
                 let val = unsafe { self.vget_unchecked_mut(j) };
-                *val = alpha * a.column(j).dot(x) + beta * *val;
+                *val = c!(alpha) * a.column(j).dot(x) + c!(beta) * o!(val);
             }
         }
     }
@@ -613,8 +615,8 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
 
         for j in 0..ncols1 {
             // FIXME: avoid bound checks.
-            let val = unsafe { *y.vget_unchecked(j) };
-            self.column_mut(j).axpy(alpha * val, x, beta);
+            let val = unsafe { o!(y.vget_unchecked(j)) };
+            self.column_mut(j).axpy(c!(alpha) * val, x, c!(beta));
         }
     }
 
@@ -747,7 +749,7 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
 
         for j1 in 0..ncols1 {
             // FIXME: avoid bound checks.
-            self.column_mut(j1).gemv(alpha, a, &b.column(j1), beta);
+            self.column_mut(j1).gemv(c!(alpha), a, &b.column(j1), c!(beta));
         }
     }
 
@@ -805,7 +807,7 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
 
         for j1 in 0..ncols1 {
             // FIXME: avoid bound checks.
-            self.column_mut(j1).gemv_tr(alpha, a, &b.column(j1), beta);
+            self.column_mut(j1).gemv_tr(c!(alpha), a, &b.column(j1), c!(beta));
         }
     }
 }
@@ -856,13 +858,13 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
         assert!(dim1 == dim2 && dim1 == dim3, "ger: dimensions mismatch.");
 
         for j in 0..dim1 {
-            let val = unsafe { *y.vget_unchecked(j) };
+            let val = unsafe { o!(y.vget_unchecked(j)) };
             let subdim = Dynamic::new(dim1 - j);
             // FIXME: avoid bound checks.
             self.generic_slice_mut((j, j), (subdim, U1)).axpy(
-                alpha * val,
+                c!(alpha) * val,
                 &x.rows_range(j..),
-                beta,
+                c!(beta),
             );
         }
     }
@@ -916,11 +918,11 @@ where N: Scalar + Zero + One + ClosedAdd + ClosedMul
         ShapeConstraint: DimEq<D1, D2> + DimEq<D1, R3> + DimEq<D2, R3> + DimEq<C3, D4>,
     {
         work.gemv(N::one(), lhs, &mid.column(0), N::zero());
-        self.ger(alpha, work, &lhs.column(0), beta);
+        self.ger(c!(alpha), work, &lhs.column(0), beta);
 
         for j in 1..mid.ncols() {
             work.gemv(N::one(), lhs, &mid.column(j), N::zero());
-            self.ger(alpha, work, &lhs.column(j), N::one());
+            self.ger(c!(alpha), work, &lhs.column(j), N::one());
         }
     }
 
@@ -1010,11 +1012,11 @@ where N: Scalar + Zero + One + ClosedAdd + ClosedMul
             DimEq<D3, R4> + DimEq<D1, C4> + DimEq<D2, D3> + AreMultipliable<C4, R4, D2, U1>,
     {
         work.gemv(N::one(), mid, &rhs.column(0), N::zero());
-        self.column_mut(0).gemv_tr(alpha, &rhs, work, beta);
+        self.column_mut(0).gemv_tr(c!(alpha), &rhs, work, c!(beta));
 
         for j in 1..rhs.ncols() {
             work.gemv(N::one(), mid, &rhs.column(j), N::zero());
-            self.column_mut(j).gemv_tr(alpha, &rhs, work, beta);
+            self.column_mut(j).gemv_tr(c!(alpha), &rhs, work, c!(beta));
         }
     }
 

--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -44,7 +44,7 @@ where
     {
         let mut res = Self::one();
         for i in 0..scaling.len() {
-            res[(i, i)] = scaling[i];
+            res[(i, i)] = o!(scaling[i]);
         }
 
         res
@@ -260,7 +260,7 @@ impl<N: Scalar + Ring, D: DimName, S: StorageMut<N, D, D>> SquareMatrix<N, D, S>
     {
         for i in 0..scaling.len() {
             let mut to_scale = self.fixed_rows_mut::<U1>(i);
-            to_scale *= scaling[i];
+            to_scale *= o!(scaling[i]);
         }
     }
 
@@ -275,7 +275,7 @@ impl<N: Scalar + Ring, D: DimName, S: StorageMut<N, D, D>> SquareMatrix<N, D, S>
     {
         for i in 0..scaling.len() {
             let mut to_scale = self.fixed_columns_mut::<U1>(i);
-            to_scale *= scaling[i];
+            to_scale *= o!(scaling[i]);
         }
     }
 
@@ -288,7 +288,7 @@ impl<N: Scalar + Ring, D: DimName, S: StorageMut<N, D, D>> SquareMatrix<N, D, S>
     {
         for i in 0..D::dim() {
             for j in 0..D::dim() - 1 {
-                self[(j, i)] += shift[j] * self[(D::dim() - 1, i)];
+                self[(j, i)] += o!(shift[j]) * o!(self[(D::dim() - 1, i)]);
             }
         }
     }

--- a/src/base/componentwise.rs
+++ b/src/base/componentwise.rs
@@ -61,7 +61,7 @@ macro_rules! component_binop_impl(
                 for j in 0 .. res.ncols() {
                     for i in 0 .. res.nrows() {
                         unsafe {
-                            res.get_unchecked_mut(i, j).$op_assign(*rhs.get_unchecked(i, j));
+                            res.get_unchecked_mut(i, j).$op_assign(o!(rhs.get_unchecked(i, j)));
                         }
                     }
                 }
@@ -89,7 +89,7 @@ macro_rules! component_binop_impl(
                     for j in 0 .. self.ncols() {
                         for i in 0 .. self.nrows() {
                             unsafe {
-                                let res = alpha * a.get_unchecked(i, j).$op(*b.get_unchecked(i, j));
+                                let res = c!(alpha) * o!(a.get_unchecked(i, j)).$op(o!(b.get_unchecked(i, j)));
                                 *self.get_unchecked_mut(i, j) = res;
                             }
                         }
@@ -99,8 +99,8 @@ macro_rules! component_binop_impl(
                     for j in 0 .. self.ncols() {
                         for i in 0 .. self.nrows() {
                             unsafe {
-                                let res = alpha * a.get_unchecked(i, j).$op(*b.get_unchecked(i, j));
-                                *self.get_unchecked_mut(i, j) = beta * *self.get_unchecked(i, j) + res;
+                                let res = c!(alpha) * o!(a.get_unchecked(i, j)).$op(o!(b.get_unchecked(i, j)));
+                                *self.get_unchecked_mut(i, j) = c!(beta) * o!(self.get_unchecked(i, j)) + res;
                             }
                         }
                     }
@@ -121,7 +121,7 @@ macro_rules! component_binop_impl(
                 for j in 0 .. self.ncols() {
                     for i in 0 .. self.nrows() {
                         unsafe {
-                            self.get_unchecked_mut(i, j).$op_assign(*rhs.get_unchecked(i, j));
+                            self.get_unchecked_mut(i, j).$op_assign(o!(rhs.get_unchecked(i, j)));
                         }
                     }
                 }

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -82,7 +82,7 @@ where DefaultAllocator: Allocator<N, R, C>
 
         for i in 0..nrows.value() {
             for j in 0..ncols.value() {
-                unsafe { *res.get_unchecked_mut(i, j) = *iter.next().unwrap() }
+                unsafe { *res.get_unchecked_mut(i, j) = o!(iter.next().unwrap()) }
             }
         }
 
@@ -132,7 +132,7 @@ where DefaultAllocator: Allocator<N, R, C>
         let mut res = Self::zeros_generic(nrows, ncols);
 
         for i in 0..::min(nrows.value(), ncols.value()) {
-            unsafe { *res.get_unchecked_mut(i, i) = elt }
+            unsafe { *res.get_unchecked_mut(i, i) = c!(elt) }
         }
 
         res
@@ -152,7 +152,7 @@ where DefaultAllocator: Allocator<N, R, C>
         );
 
         for (i, elt) in elts.iter().enumerate() {
-            unsafe { *res.get_unchecked_mut(i, i) = *elt }
+            unsafe { *res.get_unchecked_mut(i, i) = o!(elt) }
         }
 
         res
@@ -194,7 +194,7 @@ where DefaultAllocator: Allocator<N, R, C>
 
         // FIXME: optimize that.
         Self::from_fn_generic(R::from_usize(nrows), C::from_usize(ncols), |i, j| {
-            rows[i][(0, j)]
+            o!(rows[i][(0, j)])
         })
     }
 
@@ -234,7 +234,7 @@ where DefaultAllocator: Allocator<N, R, C>
 
         // FIXME: optimize that.
         Self::from_fn_generic(R::from_usize(nrows), C::from_usize(ncols), |i, j| {
-            columns[j][i]
+            o!(columns[j][i])
         })
     }
 
@@ -313,7 +313,7 @@ where
 
         for i in 0..diag.len() {
             unsafe {
-                *res.get_unchecked_mut(i, i) = *diag.vget_unchecked(i);
+                *res.get_unchecked_mut(i, i) = o!(diag.vget_unchecked(i));
             }
         }
 

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -39,7 +39,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
     #[inline]
     pub fn fill(&mut self, val: N) {
         for e in self.iter_mut() {
-            *e = val
+            *e = c!(val)
         }
     }
 
@@ -58,7 +58,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
         let n = cmp::min(nrows, ncols);
 
         for i in 0..n {
-            unsafe { *self.get_unchecked_mut(i, i) = val }
+            unsafe { *self.get_unchecked_mut(i, i) = c!(val) }
         }
     }
 
@@ -67,7 +67,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
     pub fn fill_row(&mut self, i: usize, val: N) {
         assert!(i < self.nrows(), "Row index out of bounds.");
         for j in 0..self.ncols() {
-            unsafe { *self.get_unchecked_mut(i, j) = val }
+            unsafe { *self.get_unchecked_mut(i, j) = c!(val) }
         }
     }
 
@@ -76,7 +76,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
     pub fn fill_column(&mut self, j: usize, val: N) {
         assert!(j < self.ncols(), "Row index out of bounds.");
         for i in 0..self.nrows() {
-            unsafe { *self.get_unchecked_mut(i, j) = val }
+            unsafe { *self.get_unchecked_mut(i, j) = c!(val) }
         }
     }
 
@@ -93,7 +93,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
         assert_eq!(diag.len(), min_nrows_ncols, "Mismatched dimensions.");
 
         for i in 0..min_nrows_ncols {
-            unsafe { *self.get_unchecked_mut(i, i) = *diag.vget_unchecked(i) }
+            unsafe { *self.get_unchecked_mut(i, i) = o!(diag.vget_unchecked(i)) }
         }
     }
 
@@ -128,7 +128,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
     pub fn fill_lower_triangle(&mut self, val: N, shift: usize) {
         for j in 0..self.ncols() {
             for i in (j + shift)..self.nrows() {
-                unsafe { *self.get_unchecked_mut(i, j) = val }
+                unsafe { *self.get_unchecked_mut(i, j) = c!(val) }
             }
         }
     }
@@ -146,7 +146,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
             // FIXME: is there a more efficient way to avoid the min ?
             // (necessary for rectangular matrices)
             for i in 0..cmp::min(j + 1 - shift, self.nrows()) {
-                unsafe { *self.get_unchecked_mut(i, j) = val }
+                unsafe { *self.get_unchecked_mut(i, j) = c!(val) }
             }
         }
     }
@@ -191,7 +191,7 @@ impl<N: Scalar, D: Dim, S: StorageMut<N, D, D>> Matrix<N, D, D, S> {
         for j in 0..dim {
             for i in j + 1..dim {
                 unsafe {
-                    *self.get_unchecked_mut(i, j) = *self.get_unchecked(j, i);
+                    *self.get_unchecked_mut(i, j) = o!(self.get_unchecked(j, i));
                 }
             }
         }
@@ -206,7 +206,7 @@ impl<N: Scalar, D: Dim, S: StorageMut<N, D, D>> Matrix<N, D, D, S> {
         for j in 1..self.ncols() {
             for i in 0..j {
                 unsafe {
-                    *self.get_unchecked_mut(i, j) = *self.get_unchecked(j, i);
+                    *self.get_unchecked_mut(i, j) = o!(self.get_unchecked(j, i));
                 }
             }
         }
@@ -579,7 +579,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
             let res = unsafe { DefaultAllocator::reallocate_copy(new_nrows, new_ncols, data) };
             let mut res = Matrix::from_data(res);
             if new_ncols.value() > ncols {
-                res.columns_range_mut(ncols..).fill(val);
+                res.columns_range_mut(ncols..).fill(c!(val));
             }
 
             res
@@ -613,12 +613,12 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
             }
 
             if new_ncols.value() > ncols {
-                res.columns_range_mut(ncols..).fill(val);
+                res.columns_range_mut(ncols..).fill(c!(val));
             }
 
             if new_nrows.value() > nrows {
                 res.slice_range_mut(nrows.., ..cmp::min(ncols, new_ncols.value()))
-                    .fill(val);
+                    .fill(c!(val));
             }
 
             res

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -374,7 +374,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..res.ncols() {
             for i in 0..res.nrows() {
                 unsafe {
-                    *res.get_unchecked_mut(i, j) = *self.get_unchecked(i, j);
+                    *res.get_unchecked_mut(i, j) = o!(self.get_unchecked(i, j));
                 }
             }
         }
@@ -393,7 +393,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
                 unsafe {
-                    let a = *self.data.get_unchecked(i, j);
+                    let a = o!(self.data.get_unchecked(i, j));
                     *res.data.get_unchecked_mut(i, j) = f(a)
                 }
             }
@@ -419,7 +419,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
                 unsafe {
-                    let a = *self.data.get_unchecked(i, j);
+                    let a = o!(self.data.get_unchecked(i, j));
                     *res.data.get_unchecked_mut(i, j) = f(i, j, a)
                 }
             }
@@ -451,8 +451,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
                 unsafe {
-                    let a = *self.data.get_unchecked(i, j);
-                    let b = *rhs.data.get_unchecked(i, j);
+                    let a = o!(self.data.get_unchecked(i, j));
+                    let b = o!(rhs.data.get_unchecked(i, j));
                     *res.data.get_unchecked_mut(i, j) = f(a, b)
                 }
             }
@@ -492,9 +492,9 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
                 unsafe {
-                    let a = *self.data.get_unchecked(i, j);
-                    let b = *b.data.get_unchecked(i, j);
-                    let c = *c.data.get_unchecked(i, j);
+                    let a = o!(self.data.get_unchecked(i, j));
+                    let b = o!(b.data.get_unchecked(i, j));
+                    let c = o!(c.data.get_unchecked(i, j));
                     *res.data.get_unchecked_mut(i, j) = f(a, b, c)
                 }
             }
@@ -522,7 +522,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         for i in 0..nrows {
             for j in 0..ncols {
                 unsafe {
-                    *out.get_unchecked_mut(j, i) = *self.get_unchecked(i, j);
+                    *out.get_unchecked_mut(j, i) = o!(self.get_unchecked(i, j));
                 }
             }
         }
@@ -598,7 +598,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..ncols {
             for i in 0..nrows {
                 unsafe {
-                    *self.get_unchecked_mut(i, j) = *slice.get_unchecked(i + j * nrows);
+                    *self.get_unchecked_mut(i, j) = o!(slice.get_unchecked(i + j * nrows));
                 }
             }
         }
@@ -621,7 +621,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..self.ncols() {
             for i in 0..self.nrows() {
                 unsafe {
-                    *self.get_unchecked_mut(i, j) = *other.get_unchecked(i, j);
+                    *self.get_unchecked_mut(i, j) = o!(other.get_unchecked(i, j));
                 }
             }
         }
@@ -645,7 +645,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
         for j in 0..ncols {
             for i in 0..nrows {
                 unsafe {
-                    *self.get_unchecked_mut(i, j) = *other.get_unchecked(j, i);
+                    *self.get_unchecked_mut(i, j) = o!(other.get_unchecked(j, i));
                 }
             }
         }
@@ -661,7 +661,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: StorageMut<N, R, C>> Matrix<N, R, C, S> {
             for i in 0..nrows {
                 unsafe {
                     let e = self.data.get_unchecked_mut(i, j);
-                    *e = f(*e)
+                    *e = f(o!(e))
                 }
             }
         }
@@ -803,7 +803,7 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
 
         for i in 0..dim.value() {
             unsafe {
-                *res.vget_unchecked_mut(i) = *self.get_unchecked(i, i);
+                *res.vget_unchecked_mut(i) = o!(self.get_unchecked(i, i));
             }
         }
 
@@ -823,7 +823,7 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         let mut res = N::zero();
 
         for i in 0..dim.value() {
-            res += unsafe { *self.get_unchecked(i, i) };
+            res += unsafe { o!(self.get_unchecked(i, i)) };
         }
 
         res
@@ -1084,7 +1084,7 @@ where
 
         for i in 0..nrows {
             for j in 0..ncols {
-                lengths[(i, j)] = val_width(self[(i, j)], f);
+                lengths[(i, j)] = val_width(o!(self[(i, j)]), f);
                 max_length = ::max(max_length, lengths[(i, j)]);
             }
         }
@@ -1139,8 +1139,8 @@ impl<N: Scalar + Ring, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         assert!(self.shape() == (2, 1), "2D perpendicular product ");
 
         unsafe {
-            *self.get_unchecked(0, 0) * *b.get_unchecked(1, 0)
-                - *self.get_unchecked(1, 0) * *b.get_unchecked(0, 0)
+            o!(self.get_unchecked(0, 0)) * o!(b.get_unchecked(1, 0))
+                - o!(self.get_unchecked(1, 0)) * o!(b.get_unchecked(0, 0))
         }
     }
 
@@ -1175,17 +1175,17 @@ impl<N: Scalar + Ring, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
                 let ncols = SameShapeC::<C, C2>::from_usize(1);
                 let mut res = Matrix::new_uninitialized_generic(nrows, ncols);
 
-                let ax = *self.get_unchecked(0, 0);
-                let ay = *self.get_unchecked(1, 0);
-                let az = *self.get_unchecked(2, 0);
+                let ax = o!(self.get_unchecked(0, 0));
+                let ay = o!(self.get_unchecked(1, 0));
+                let az = o!(self.get_unchecked(2, 0));
 
-                let bx = *b.get_unchecked(0, 0);
-                let by = *b.get_unchecked(1, 0);
-                let bz = *b.get_unchecked(2, 0);
+                let bx = o!(b.get_unchecked(0, 0));
+                let by = o!(b.get_unchecked(1, 0));
+                let bz = o!(b.get_unchecked(2, 0));
 
-                *res.get_unchecked_mut(0, 0) = ay * bz - az * by;
-                *res.get_unchecked_mut(1, 0) = az * bx - ax * bz;
-                *res.get_unchecked_mut(2, 0) = ax * by - ay * bx;
+                *res.get_unchecked_mut(0, 0) = c!(ay) * c!(bz) - c!(az) * c!(by);
+                *res.get_unchecked_mut(1, 0) = c!(az) * c!(bx) - c!(ax) * c!(bz);
+                *res.get_unchecked_mut(2, 0) = c!(ax) * c!(by) - c!(ay) * c!(bx);
 
                 res
             }
@@ -1196,17 +1196,17 @@ impl<N: Scalar + Ring, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
                 let ncols = SameShapeC::<C, C2>::from_usize(3);
                 let mut res = Matrix::new_uninitialized_generic(nrows, ncols);
 
-                let ax = *self.get_unchecked(0, 0);
-                let ay = *self.get_unchecked(0, 1);
-                let az = *self.get_unchecked(0, 2);
+                let ax = o!(self.get_unchecked(0, 0));
+                let ay = o!(self.get_unchecked(0, 1));
+                let az = o!(self.get_unchecked(0, 2));
 
-                let bx = *b.get_unchecked(0, 0);
-                let by = *b.get_unchecked(0, 1);
-                let bz = *b.get_unchecked(0, 2);
+                let bx = o!(b.get_unchecked(0, 0));
+                let by = o!(b.get_unchecked(0, 1));
+                let bz = o!(b.get_unchecked(0, 2));
 
-                *res.get_unchecked_mut(0, 0) = ay * bz - az * by;
-                *res.get_unchecked_mut(0, 1) = az * bx - ax * bz;
-                *res.get_unchecked_mut(0, 2) = ax * by - ay * bx;
+                *res.get_unchecked_mut(0, 0) = c!(ay) * c!(bz) - c!(az) * c!(by);
+                *res.get_unchecked_mut(0, 1) = c!(az) * c!(bx) - c!(ax) * c!(bz);
+                *res.get_unchecked_mut(0, 2) = c!(ax )* c!(by) - c!(ay) * c!(bx);
 
                 res
             }
@@ -1341,7 +1341,7 @@ impl<N: Scalar + Zero + One + ClosedAdd + ClosedSub + ClosedMul, D: Dim, S: Stor
     pub fn lerp<S2: Storage<N, D>>(&self, rhs: &Vector<N, D, S2>, t: N) -> VectorN<N, D>
     where DefaultAllocator: Allocator<N, D> {
         let mut res = self.clone_owned();
-        res.axpy(t, rhs, N::one() - t);
+        res.axpy(c!(t), rhs, N::one() - c!(t));
         res
     }
 }

--- a/src/base/matrix_vec.rs
+++ b/src/base/matrix_vec.rs
@@ -290,7 +290,8 @@ where
         self.data.reserve(nrows * lower);
         for vector in iter {
             assert_eq!(nrows, vector.shape().0);
-            self.data.extend(vector.iter());
+            // I'm sure we can do better than this, but the easiest thing I can think of rn is to force Storage to consume itself and return an iter, and then wrap that in Matrix
+            self.data.extend(vector.iter().map(|x| x.to_owned()));
         }
         self.ncols = Dynamic::new(self.data.len() / nrows);
     }

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -119,7 +119,7 @@ where
     #[inline]
     pub fn neg_mut(&mut self) {
         for e in self.iter_mut() {
-            *e = -*e
+            *e = -o!(e)
         }
     }
 }
@@ -164,7 +164,7 @@ macro_rules! componentwise_binop_impl(
                     let out  = out.data.as_mut_slice();
                     for i in 0 .. arr1.len() {
                         unsafe {
-                            *out.get_unchecked_mut(i) = arr1.get_unchecked(i).$method(*arr2.get_unchecked(i));
+                            *out.get_unchecked_mut(i) = o!(arr1.get_unchecked(i)).$method(o!(arr2.get_unchecked(i)));
                         }
                     }
                 }
@@ -172,7 +172,7 @@ macro_rules! componentwise_binop_impl(
                     for j in 0 .. self.ncols() {
                         for i in 0 .. self.nrows() {
                             unsafe {
-                                let val = self.get_unchecked(i, j).$method(*rhs.get_unchecked(i, j));
+                                let val = o!(self.get_unchecked(i, j)).$method(o!(rhs.get_unchecked(i, j)));
                                 *out.get_unchecked_mut(i, j) = val;
                             }
                         }
@@ -196,7 +196,7 @@ macro_rules! componentwise_binop_impl(
                     let arr2 = rhs.data.as_slice();
                     for i in 0 .. arr2.len() {
                         unsafe {
-                            arr1.get_unchecked_mut(i).$method_assign(*arr2.get_unchecked(i));
+                            arr1.get_unchecked_mut(i).$method_assign(o!(arr2.get_unchecked(i)));
                         }
                     }
                 }
@@ -204,7 +204,7 @@ macro_rules! componentwise_binop_impl(
                     for j in 0 .. rhs.ncols() {
                         for i in 0 .. rhs.nrows() {
                             unsafe {
-                                self.get_unchecked_mut(i, j).$method_assign(*rhs.get_unchecked(i, j))
+                                self.get_unchecked_mut(i, j).$method_assign(o!(rhs.get_unchecked(i, j)))
                             }
                         }
                     }
@@ -226,7 +226,7 @@ macro_rules! componentwise_binop_impl(
                     let arr2 = rhs.data.as_mut_slice();
                     for i in 0 .. arr1.len() {
                         unsafe {
-                            let res = arr1.get_unchecked(i).$method(*arr2.get_unchecked(i));
+                            let res = o!(arr1.get_unchecked(i)).$method(o!(arr2.get_unchecked(i)));
                             *arr2.get_unchecked_mut(i) = res;
                         }
                     }
@@ -236,7 +236,7 @@ macro_rules! componentwise_binop_impl(
                         for i in 0 .. self.nrows() {
                             unsafe {
                                 let r = rhs.get_unchecked_mut(i, j);
-                                *r = self.get_unchecked(i, j).$method(*r)
+                                *r = o!(self.get_unchecked(i, j)).$method(o!(r))
                             }
                         }
                     }
@@ -422,7 +422,7 @@ macro_rules! componentwise_scalarop_impl(
 
                 // for left in res.iter_mut() {
                 for left in res.as_mut_slice().iter_mut() {
-                    *left = left.$method(rhs)
+                    *left = o!(left).$method(o!(rhs))
                 }
 
                 res
@@ -448,7 +448,7 @@ macro_rules! componentwise_scalarop_impl(
             fn $method_assign(&mut self, rhs: N) {
                 for j in 0 .. self.ncols() {
                     for i in 0 .. self.nrows() {
-                        unsafe { self.get_unchecked_mut(i, j).$method_assign(rhs) };
+                        unsafe { self.get_unchecked_mut(i, j).$method_assign(o!(rhs)) };
                     }
                 }
             }
@@ -704,10 +704,10 @@ where
                 for j2 in 0..ncols2.value() {
                     for i1 in 0..nrows1.value() {
                         unsafe {
-                            let coeff = *self.get_unchecked(i1, j1);
+                            let coeff = o!(self.get_unchecked(i1, j1));
 
                             for i2 in 0..nrows2.value() {
-                                *data_res = coeff * *rhs.get_unchecked(i2, j2);
+                                *data_res = c!(coeff) * o!(rhs.get_unchecked(i2, j2));
                                 data_res = data_res.offset(1);
                             }
                         }
@@ -735,7 +735,7 @@ impl<N: Scalar + ClosedAdd, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C,
     pub fn add_scalar_mut(&mut self, rhs: N)
     where S: StorageMut<N, R, C> {
         for e in self.iter_mut() {
-            *e += rhs
+            *e += c!(rhs)
         }
     }
 }

--- a/src/base/scalar.rs
+++ b/src/base/scalar.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 /// The basic scalar type for all structures of `nalgebra`.
 ///
 /// This does not make any assumption on the algebraic properties of `Self`.
-pub trait Scalar: Copy + PartialEq + Debug + Any {
+pub trait Scalar: Clone + PartialEq + Debug + Any {
     #[inline]
     /// Tests if `Self` the same as the type `T`
     ///
@@ -14,4 +14,4 @@ pub trait Scalar: Copy + PartialEq + Debug + Any {
         TypeId::of::<Self>() == TypeId::of::<T>()
     }
 }
-impl<T: Copy + PartialEq + Debug + Any> Scalar for T {}
+impl<T: Clone + PartialEq + Debug + Any> Scalar for T {}

--- a/src/base/swizzle.rs
+++ b/src/base/swizzle.rs
@@ -12,7 +12,7 @@ macro_rules! impl_swizzle {
                     /// Builds a new vector from components of `self`.
                     #[inline]
                     pub fn $name(&self) -> $Result<N> {
-                        $Result::new($(self[$i]),*)
+                        $Result::new($(o!(self[$i])),*)
                     }
                 )*
             }

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -37,7 +37,7 @@ where
     }
 }
 
-impl<N: Scalar, D: DimName> Copy for Point<N, D>
+impl<N: Scalar + Copy, D: DimName> Copy for Point<N, D>
 where
     DefaultAllocator: Allocator<N, D>,
     <DefaultAllocator as Allocator<N, D>>::Buffer: Copy,

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -99,7 +99,7 @@ where DefaultAllocator: Allocator<N, D>
         DefaultAllocator: Allocator<N, DimNameSum<D, U1>>,
     {
         if !v[D::dim()].is_zero() {
-            let coords = v.fixed_slice::<D, U1>(0, 0) / v[D::dim()];
+            let coords = v.fixed_slice::<D, U1>(0, 0) / o!(v[D::dim()]);
             Some(Self::from(coords))
         } else {
             None

--- a/src/geometry/point_conversion.rs
+++ b/src/geometry/point_conversion.rs
@@ -72,7 +72,7 @@ where
 
     #[inline]
     unsafe fn from_superset_unchecked(v: &VectorN<N2, DimNameSum<D, U1>>) -> Self {
-        let coords = v.fixed_slice::<D, U1>(0, 0) / v[D::dim()];
+        let coords = v.fixed_slice::<D, U1>(0, 0) / o!(v[D::dim()]);
         Self {
             coords: ::convert_unchecked(coords)
         }

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -39,7 +39,7 @@ where
     }
 }
 
-impl<N: Scalar, D: DimName> Copy for Rotation<N, D>
+impl<N: Scalar + Copy, D: DimName> Copy for Rotation<N, D>
 where
     DefaultAllocator: Allocator<N, D, D>,
     <DefaultAllocator as Allocator<N, D, D>>::Buffer: Copy,

--- a/src/geometry/swizzle.rs
+++ b/src/geometry/swizzle.rs
@@ -15,7 +15,7 @@ macro_rules! impl_swizzle {
                     /// Builds a new point from components of `self`.
                     #[inline]
                     pub fn $name(&self) -> $Result<N> {
-                        $Result::new($(self[$i]),*)
+                        $Result::new($(o!(self[$i])),*)
                     }
                 )*
             }

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -39,7 +39,7 @@ where
     }
 }
 
-impl<N: Scalar, D: DimName> Copy for Translation<N, D>
+impl<N: Scalar + Copy, D: DimName> Copy for Translation<N, D>
 where
     DefaultAllocator: Allocator<N, D>,
     Owned<N, D>: Copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ an optimized set of tools for computer graphics and physics. Those features incl
 // #![feature(plugin)]
 //
 // #![plugin(clippy)]
-
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
 #![deny(non_upper_case_globals)]
@@ -87,6 +86,8 @@ an optimized set of tools for computer graphics and physics. Those features incl
        html_root_url = "http://nalgebra.org/rustdoc")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+
+//#[macro_use]
 
 #[cfg(feature = "arbitrary")]
 extern crate quickcheck;
@@ -120,6 +121,19 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 extern crate core as std;
+
+// to_owned
+macro_rules! o {
+    ($e:expr) => {
+        $e.to_owned()
+    };
+}
+
+macro_rules! c {
+    ($e:expr) => {
+        $e.clone()
+    };
+}
 
 pub mod base;
 #[cfg(feature = "debug")]
@@ -635,3 +649,4 @@ pub fn try_convert_ref<From: SupersetOf<To>, To>(t: &From) -> Option<To> {
 pub unsafe fn convert_ref_unchecked<From: SupersetOf<To>, To>(t: &From) -> To {
     t.to_subset_unchecked()
 }
+

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -333,7 +333,7 @@ where
     let (pivot_row, mut down) = submat.rows_range_pair_mut(0, 1..);
 
     for k in 0..pivot_row.ncols() {
-        down.column_mut(k).axpy(-pivot_row[k], &coeffs, N::one());
+        down.column_mut(k).axpy(-o!(pivot_row[k]), &coeffs, N::one());
     }
 }
 
@@ -364,7 +364,7 @@ pub fn gauss_step_swap<N, R: Dim, C: Dim, S>(
 
     for k in 0..pivot_row.ncols() {
         mem::swap(&mut pivot_row[k], &mut down[(piv - 1, k)]);
-        down.column_mut(k).axpy(-pivot_row[k], &coeffs, N::one());
+        down.column_mut(k).axpy(-o!(pivot_row[k]), &coeffs, N::one());
     }
 }
 


### PR DESCRIPTION
Fixes #282.
This is the first of two parts, if you accept the PR, I'll work on accepting references for functions/methods that have a scalar as a parameter.

There are two macros I defined, `c`, and `o`. running `c!(x)` does `x.clone()`, and `o!(x)` does `x.to_owned()`. These make the source code quite a bit more clean than writing` clone` and `to_owned` out every time.