### PR TITLE
Storage type name reform.

### DIFF
--- a/src/base/alias.rs
+++ b/src/base/alias.rs
@@ -2,7 +2,7 @@
 use base::dimension::Dynamic;
 use base::dimension::{U1, U2, U3, U4, U5, U6};
 #[cfg(any(feature = "std", feature = "alloc"))]
-use base::matrix_vec::MatrixVec;
+use base::vec_storage::VecStorage;
 use base::storage::Owned;
 use base::Matrix;
 
@@ -119,7 +119,7 @@ pub type Matrix6x5<N> = MatrixMN<N, U6, U5>;
  */
 /// A dynamically sized column vector.
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type DVector<N> = Matrix<N, Dynamic, U1, MatrixVec<N, Dynamic, U1>>;
+pub type DVector<N> = Matrix<N, Dynamic, U1, VecStorage<N, Dynamic, U1>>;
 
 /// A statically sized D-dimensional column vector.
 pub type VectorN<N, D> = MatrixMN<N, D, U1>;
@@ -146,7 +146,7 @@ pub type Vector6<N> = VectorN<N, U6>;
  */
 /// A dynamically sized row vector.
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type RowDVector<N> = Matrix<N, U1, Dynamic, MatrixVec<N, U1, Dynamic>>;
+pub type RowDVector<N> = Matrix<N, U1, Dynamic, VecStorage<N, U1, Dynamic>>;
 
 /// A statically sized D-dimensional row vector.
 pub type RowVectorN<N, D> = MatrixMN<N, U1, D>;

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -34,7 +34,7 @@ use base::Scalar;
  */
 /// A array-based statically sized matrix data storage.
 #[repr(C)]
-pub struct MatrixArray<N, R, C>
+pub struct ArrayStorage<N, R, C>
 where
     R: DimName,
     C: DimName,
@@ -44,7 +44,11 @@ where
     data: GenericArray<N, Prod<R::Value, C::Value>>,
 }
 
-impl<N, R, C> Hash for MatrixArray<N, R, C>
+#[deprecated(note="renamed to `ArrayStorage`")]
+/// Renamed to [ArrayStorage].
+pub type MatrixArray<N, R, C> = ArrayStorage<N, R, C>;
+
+impl<N, R, C> Hash for ArrayStorage<N, R, C>
 where
     N: Hash,
     R: DimName,
@@ -57,7 +61,7 @@ where
     }
 }
 
-impl<N, R, C> Deref for MatrixArray<N, R, C>
+impl<N, R, C> Deref for ArrayStorage<N, R, C>
 where
     R: DimName,
     C: DimName,
@@ -72,7 +76,7 @@ where
     }
 }
 
-impl<N, R, C> DerefMut for MatrixArray<N, R, C>
+impl<N, R, C> DerefMut for ArrayStorage<N, R, C>
 where
     R: DimName,
     C: DimName,
@@ -85,7 +89,7 @@ where
     }
 }
 
-impl<N, R, C> Debug for MatrixArray<N, R, C>
+impl<N, R, C> Debug for ArrayStorage<N, R, C>
 where
     N: Debug,
     R: DimName,
@@ -99,7 +103,7 @@ where
     }
 }
 
-impl<N, R, C> Copy for MatrixArray<N, R, C>
+impl<N, R, C> Copy for ArrayStorage<N, R, C>
 where
     N: Copy,
     R: DimName,
@@ -109,7 +113,7 @@ where
     GenericArray<N, Prod<R::Value, C::Value>>: Copy,
 {}
 
-impl<N, R, C> Clone for MatrixArray<N, R, C>
+impl<N, R, C> Clone for ArrayStorage<N, R, C>
 where
     N: Clone,
     R: DimName,
@@ -119,13 +123,13 @@ where
 {
     #[inline]
     fn clone(&self) -> Self {
-        MatrixArray {
+        ArrayStorage {
             data: self.data.clone(),
         }
     }
 }
 
-impl<N, R, C> Eq for MatrixArray<N, R, C>
+impl<N, R, C> Eq for ArrayStorage<N, R, C>
 where
     N: Eq,
     R: DimName,
@@ -134,7 +138,7 @@ where
     Prod<R::Value, C::Value>: ArrayLength<N>,
 {}
 
-impl<N, R, C> PartialEq for MatrixArray<N, R, C>
+impl<N, R, C> PartialEq for ArrayStorage<N, R, C>
 where
     N: PartialEq,
     R: DimName,
@@ -148,7 +152,7 @@ where
     }
 }
 
-unsafe impl<N, R, C> Storage<N, R, C> for MatrixArray<N, R, C>
+unsafe impl<N, R, C> Storage<N, R, C> for ArrayStorage<N, R, C>
 where
     N: Scalar,
     R: DimName,
@@ -200,7 +204,7 @@ where
     }
 }
 
-unsafe impl<N, R, C> StorageMut<N, R, C> for MatrixArray<N, R, C>
+unsafe impl<N, R, C> StorageMut<N, R, C> for ArrayStorage<N, R, C>
 where
     N: Scalar,
     R: DimName,
@@ -220,7 +224,7 @@ where
     }
 }
 
-unsafe impl<N, R, C> ContiguousStorage<N, R, C> for MatrixArray<N, R, C>
+unsafe impl<N, R, C> ContiguousStorage<N, R, C> for ArrayStorage<N, R, C>
 where
     N: Scalar,
     R: DimName,
@@ -230,7 +234,7 @@ where
     DefaultAllocator: Allocator<N, R, C, Buffer = Self>,
 {}
 
-unsafe impl<N, R, C> ContiguousStorageMut<N, R, C> for MatrixArray<N, R, C>
+unsafe impl<N, R, C> ContiguousStorageMut<N, R, C> for ArrayStorage<N, R, C>
 where
     N: Scalar,
     R: DimName,
@@ -247,7 +251,7 @@ where
  */
 // XXX: open an issue for GenericArray so that it implements serde traits?
 #[cfg(feature = "serde-serialize")]
-impl<N, R, C> Serialize for MatrixArray<N, R, C>
+impl<N, R, C> Serialize for ArrayStorage<N, R, C>
 where
     N: Scalar + Serialize,
     R: DimName,
@@ -268,7 +272,7 @@ where
 }
 
 #[cfg(feature = "serde-serialize")]
-impl<'a, N, R, C> Deserialize<'a> for MatrixArray<N, R, C>
+impl<'a, N, R, C> Deserialize<'a> for ArrayStorage<N, R, C>
 where
     N: Scalar + Deserialize<'a>,
     R: DimName,
@@ -278,18 +282,18 @@ where
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'a> {
-        deserializer.deserialize_seq(MatrixArrayVisitor::new())
+        deserializer.deserialize_seq(ArrayStorageVisitor::new())
     }
 }
 
 #[cfg(feature = "serde-serialize")]
 /// A visitor that produces a matrix array.
-struct MatrixArrayVisitor<N, R, C> {
+struct ArrayStorageVisitor<N, R, C> {
     marker: PhantomData<(N, R, C)>,
 }
 
 #[cfg(feature = "serde-serialize")]
-impl<N, R, C> MatrixArrayVisitor<N, R, C>
+impl<N, R, C> ArrayStorageVisitor<N, R, C>
 where
     N: Scalar,
     R: DimName,
@@ -299,14 +303,14 @@ where
 {
     /// Construct a new sequence visitor.
     pub fn new() -> Self {
-        MatrixArrayVisitor {
+        ArrayStorageVisitor {
             marker: PhantomData,
         }
     }
 }
 
 #[cfg(feature = "serde-serialize")]
-impl<'a, N, R, C> Visitor<'a> for MatrixArrayVisitor<N, R, C>
+impl<'a, N, R, C> Visitor<'a> for ArrayStorageVisitor<N, R, C>
 where
     N: Scalar + Deserialize<'a>,
     R: DimName,
@@ -314,14 +318,14 @@ where
     R::Value: Mul<C::Value>,
     Prod<R::Value, C::Value>: ArrayLength<N>,
 {
-    type Value = MatrixArray<N, R, C>;
+    type Value = ArrayStorage<N, R, C>;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
         formatter.write_str("a matrix array")
     }
 
     #[inline]
-    fn visit_seq<V>(self, mut visitor: V) -> Result<MatrixArray<N, R, C>, V::Error>
+    fn visit_seq<V>(self, mut visitor: V) -> Result<ArrayStorage<N, R, C>, V::Error>
     where V: SeqAccess<'a> {
         let mut out: Self::Value = unsafe { mem::uninitialized() };
         let mut curr = 0;
@@ -340,7 +344,7 @@ where
 }
 
 #[cfg(feature = "abomonation-serialize")]
-impl<N, R, C> Abomonation for MatrixArray<N, R, C>
+impl<N, R, C> Abomonation for ArrayStorage<N, R, C>
 where
     R: DimName,
     C: DimName,

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -17,7 +17,7 @@ use base::dimension::{
 use base::iter::{MatrixIter, MatrixIterMut};
 use base::storage::{ContiguousStorage, ContiguousStorageMut, Storage, StorageMut};
 #[cfg(any(feature = "std", feature = "alloc"))]
-use base::MatrixVec;
+use base::VecStorage;
 use base::{DefaultAllocator, Matrix, ArrayStorage, MatrixMN, MatrixSlice, MatrixSliceMut, Scalar};
 
 // FIXME: too bad this won't work allo slice conversions.
@@ -353,7 +353,7 @@ where
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, C, RStride, CStride> From<MatrixSlice<'a, N, Dynamic, C, RStride, CStride>>
-    for Matrix<N, Dynamic, C, MatrixVec<N, Dynamic, C>>
+    for Matrix<N, Dynamic, C, VecStorage<N, Dynamic, C>>
 where
     N: Scalar,
     C: Dim,
@@ -367,7 +367,7 @@ where
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, R, RStride, CStride> From<MatrixSlice<'a, N, R, Dynamic, RStride, CStride>>
-    for Matrix<N, R, Dynamic, MatrixVec<N, R, Dynamic>>
+    for Matrix<N, R, Dynamic, VecStorage<N, R, Dynamic>>
 where
     N: Scalar,
     R: DimName,
@@ -397,7 +397,7 @@ where
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, C, RStride, CStride> From<MatrixSliceMut<'a, N, Dynamic, C, RStride, CStride>>
-    for Matrix<N, Dynamic, C, MatrixVec<N, Dynamic, C>>
+    for Matrix<N, Dynamic, C, VecStorage<N, Dynamic, C>>
 where
     N: Scalar,
     C: Dim,
@@ -411,7 +411,7 @@ where
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, N, R, RStride, CStride> From<MatrixSliceMut<'a, N, R, Dynamic, RStride, CStride>>
-    for Matrix<N, R, Dynamic, MatrixVec<N, R, Dynamic>>
+    for Matrix<N, R, Dynamic, VecStorage<N, R, Dynamic>>
 where
     N: Scalar,
     R: DimName,

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -18,7 +18,7 @@ use base::iter::{MatrixIter, MatrixIterMut};
 use base::storage::{ContiguousStorage, ContiguousStorageMut, Storage, StorageMut};
 #[cfg(any(feature = "std", feature = "alloc"))]
 use base::MatrixVec;
-use base::{DefaultAllocator, Matrix, MatrixArray, MatrixMN, MatrixSlice, MatrixSliceMut, Scalar};
+use base::{DefaultAllocator, Matrix, ArrayStorage, MatrixMN, MatrixSlice, MatrixSliceMut, Scalar};
 
 // FIXME: too bad this won't work allo slice conversions.
 impl<N1, N2, R1, C1, R2, C2> SubsetOf<MatrixMN<N2, R2, C2>> for MatrixMN<N1, R1, C1>
@@ -336,7 +336,7 @@ impl_from_into_mint_2D!(
 );
 
 impl<'a, N, R, C, RStride, CStride> From<MatrixSlice<'a, N, R, C, RStride, CStride>>
-    for Matrix<N, R, C, MatrixArray<N, R, C>>
+    for Matrix<N, R, C, ArrayStorage<N, R, C>>
 where
     N: Scalar,
     R: DimName,
@@ -380,7 +380,7 @@ where
 }
 
 impl<'a, N, R, C, RStride, CStride> From<MatrixSliceMut<'a, N, R, C, RStride, CStride>>
-    for Matrix<N, R, C, MatrixArray<N, R, C>>
+    for Matrix<N, R, C, ArrayStorage<N, R, C>>
 where
     N: Scalar,
     R: DimName,

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -20,7 +20,7 @@ use base::dimension::Dynamic;
 use base::dimension::{Dim, DimName};
 use base::array_storage::ArrayStorage;
 #[cfg(any(feature = "std", feature = "alloc"))]
-use base::matrix_vec::MatrixVec;
+use base::vec_storage::VecStorage;
 use base::storage::{Storage, StorageMut};
 use base::Scalar;
 
@@ -29,7 +29,7 @@ use base::Scalar;
  * Allocator.
  *
  */
-/// An allocator based on `GenericArray` and `MatrixVec` for statically-sized and dynamically-sized
+/// An allocator based on `GenericArray` and `VecStorage` for statically-sized and dynamically-sized
 /// matrices respectively.
 pub struct DefaultAllocator;
 
@@ -77,7 +77,7 @@ where
 // Dynamic - Dynamic
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<N: Scalar, C: Dim> Allocator<N, Dynamic, C> for DefaultAllocator {
-    type Buffer = MatrixVec<N, Dynamic, C>;
+    type Buffer = VecStorage<N, Dynamic, C>;
 
     #[inline]
     unsafe fn allocate_uninitialized(nrows: Dynamic, ncols: C) -> Self::Buffer {
@@ -86,7 +86,7 @@ impl<N: Scalar, C: Dim> Allocator<N, Dynamic, C> for DefaultAllocator {
         res.reserve_exact(length);
         res.set_len(length);
 
-        MatrixVec::new(nrows, ncols, res)
+        VecStorage::new(nrows, ncols, res)
     }
 
     #[inline]
@@ -101,14 +101,14 @@ impl<N: Scalar, C: Dim> Allocator<N, Dynamic, C> for DefaultAllocator {
         assert!(res.len() == nrows.value() * ncols.value(),
                 "Allocation from iterator error: the iterator did not yield the correct number of elements.");
 
-        MatrixVec::new(nrows, ncols, res)
+        VecStorage::new(nrows, ncols, res)
     }
 }
 
 // Static - Dynamic
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<N: Scalar, R: DimName> Allocator<N, R, Dynamic> for DefaultAllocator {
-    type Buffer = MatrixVec<N, R, Dynamic>;
+    type Buffer = VecStorage<N, R, Dynamic>;
 
     #[inline]
     unsafe fn allocate_uninitialized(nrows: R, ncols: Dynamic) -> Self::Buffer {
@@ -117,7 +117,7 @@ impl<N: Scalar, R: DimName> Allocator<N, R, Dynamic> for DefaultAllocator {
         res.reserve_exact(length);
         res.set_len(length);
 
-        MatrixVec::new(nrows, ncols, res)
+        VecStorage::new(nrows, ncols, res)
     }
 
     #[inline]
@@ -132,7 +132,7 @@ impl<N: Scalar, R: DimName> Allocator<N, R, Dynamic> for DefaultAllocator {
         assert!(res.len() == nrows.value() * ncols.value(),
                 "Allocation from iterator error: the iterator did not yield the correct number of elements.");
 
-        MatrixVec::new(nrows, ncols, res)
+        VecStorage::new(nrows, ncols, res)
     }
 }
 
@@ -186,7 +186,7 @@ where
         rto: Dynamic,
         cto: CTo,
         buf: ArrayStorage<N, RFrom, CFrom>,
-    ) -> MatrixVec<N, Dynamic, CTo>
+    ) -> VecStorage<N, Dynamic, CTo>
     {
         let mut res = <Self as Allocator<N, Dynamic, CTo>>::allocate_uninitialized(rto, cto);
 
@@ -215,7 +215,7 @@ where
         rto: RTo,
         cto: Dynamic,
         buf: ArrayStorage<N, RFrom, CFrom>,
-    ) -> MatrixVec<N, RTo, Dynamic>
+    ) -> VecStorage<N, RTo, Dynamic>
     {
         let mut res = <Self as Allocator<N, RTo, Dynamic>>::allocate_uninitialized(rto, cto);
 
@@ -238,11 +238,11 @@ impl<N: Scalar, CFrom: Dim, CTo: Dim> Reallocator<N, Dynamic, CFrom, Dynamic, CT
     unsafe fn reallocate_copy(
         rto: Dynamic,
         cto: CTo,
-        buf: MatrixVec<N, Dynamic, CFrom>,
-    ) -> MatrixVec<N, Dynamic, CTo>
+        buf: VecStorage<N, Dynamic, CFrom>,
+    ) -> VecStorage<N, Dynamic, CTo>
     {
         let new_buf = buf.resize(rto.value() * cto.value());
-        MatrixVec::new(rto, cto, new_buf)
+        VecStorage::new(rto, cto, new_buf)
     }
 }
 
@@ -254,11 +254,11 @@ impl<N: Scalar, CFrom: Dim, RTo: DimName> Reallocator<N, Dynamic, CFrom, RTo, Dy
     unsafe fn reallocate_copy(
         rto: RTo,
         cto: Dynamic,
-        buf: MatrixVec<N, Dynamic, CFrom>,
-    ) -> MatrixVec<N, RTo, Dynamic>
+        buf: VecStorage<N, Dynamic, CFrom>,
+    ) -> VecStorage<N, RTo, Dynamic>
     {
         let new_buf = buf.resize(rto.value() * cto.value());
-        MatrixVec::new(rto, cto, new_buf)
+        VecStorage::new(rto, cto, new_buf)
     }
 }
 
@@ -270,11 +270,11 @@ impl<N: Scalar, RFrom: DimName, CTo: Dim> Reallocator<N, RFrom, Dynamic, Dynamic
     unsafe fn reallocate_copy(
         rto: Dynamic,
         cto: CTo,
-        buf: MatrixVec<N, RFrom, Dynamic>,
-    ) -> MatrixVec<N, Dynamic, CTo>
+        buf: VecStorage<N, RFrom, Dynamic>,
+    ) -> VecStorage<N, Dynamic, CTo>
     {
         let new_buf = buf.resize(rto.value() * cto.value());
-        MatrixVec::new(rto, cto, new_buf)
+        VecStorage::new(rto, cto, new_buf)
     }
 }
 
@@ -286,10 +286,10 @@ impl<N: Scalar, RFrom: DimName, RTo: DimName> Reallocator<N, RFrom, Dynamic, RTo
     unsafe fn reallocate_copy(
         rto: RTo,
         cto: Dynamic,
-        buf: MatrixVec<N, RFrom, Dynamic>,
-    ) -> MatrixVec<N, RTo, Dynamic>
+        buf: VecStorage<N, RFrom, Dynamic>,
+    ) -> VecStorage<N, RTo, Dynamic>
     {
         let new_buf = buf.resize(rto.value() * cto.value());
-        MatrixVec::new(rto, cto, new_buf)
+        VecStorage::new(rto, cto, new_buf)
     }
 }

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -18,7 +18,7 @@ use base::allocator::{Allocator, Reallocator};
 #[cfg(any(feature = "alloc", feature = "std"))]
 use base::dimension::Dynamic;
 use base::dimension::{Dim, DimName};
-use base::matrix_array::MatrixArray;
+use base::array_storage::ArrayStorage;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use base::matrix_vec::MatrixVec;
 use base::storage::{Storage, StorageMut};
@@ -42,7 +42,7 @@ where
     R::Value: Mul<C::Value>,
     Prod<R::Value, C::Value>: ArrayLength<N>,
 {
-    type Buffer = MatrixArray<N, R, C>;
+    type Buffer = ArrayStorage<N, R, C>;
 
     #[inline]
     unsafe fn allocate_uninitialized(_: R, _: C) -> Self::Buffer {
@@ -157,7 +157,7 @@ where
         rto: RTo,
         cto: CTo,
         buf: <Self as Allocator<N, RFrom, CFrom>>::Buffer,
-    ) -> MatrixArray<N, RTo, CTo>
+    ) -> ArrayStorage<N, RTo, CTo>
     {
         let mut res = <Self as Allocator<N, RTo, CTo>>::allocate_uninitialized(rto, cto);
 
@@ -185,7 +185,7 @@ where
     unsafe fn reallocate_copy(
         rto: Dynamic,
         cto: CTo,
-        buf: MatrixArray<N, RFrom, CFrom>,
+        buf: ArrayStorage<N, RFrom, CFrom>,
     ) -> MatrixVec<N, Dynamic, CTo>
     {
         let mut res = <Self as Allocator<N, Dynamic, CTo>>::allocate_uninitialized(rto, cto);
@@ -214,7 +214,7 @@ where
     unsafe fn reallocate_copy(
         rto: RTo,
         cto: Dynamic,
-        buf: MatrixArray<N, RFrom, CFrom>,
+        buf: ArrayStorage<N, RFrom, CFrom>,
     ) -> MatrixVec<N, RTo, Dynamic>
     {
         let mut res = <Self as Allocator<N, RTo, Dynamic>>::allocate_uninitialized(rto, cto);

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -20,7 +20,7 @@ mod conversion;
 mod edition;
 mod matrix;
 mod matrix_alga;
-mod matrix_array;
+mod array_storage;
 mod matrix_slice;
 #[cfg(any(feature = "std", feature = "alloc"))]
 mod matrix_vec;
@@ -41,7 +41,7 @@ pub use self::dimension::*;
 
 pub use self::alias::*;
 pub use self::alias_slice::*;
-pub use self::matrix_array::*;
+pub use self::array_storage::*;
 pub use self::matrix_slice::*;
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub use self::matrix_vec::*;

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -23,7 +23,7 @@ mod matrix_alga;
 mod array_storage;
 mod matrix_slice;
 #[cfg(any(feature = "std", feature = "alloc"))]
-mod matrix_vec;
+mod vec_storage;
 mod properties;
 mod scalar;
 mod swizzle;
@@ -44,4 +44,4 @@ pub use self::alias_slice::*;
 pub use self::array_storage::*;
 pub use self::matrix_slice::*;
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use self::matrix_vec::*;
+pub use self::vec_storage::*;

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -34,7 +34,7 @@ pub type CStride<N, R, C = U1> =
 /// Note that `Self` must always have a number of elements compatible with the matrix length (given
 /// by `R` and `C` if they are known at compile-time). For example, implementors of this trait
 /// should **not** allow the user to modify the size of the underlying buffer with safe methods
-/// (for example the `MatrixVec::data_mut` method is unsafe because the user could change the
+/// (for example the `VecStorage::data_mut` method is unsafe because the user could change the
 /// vector's size so that it no longer contains enough elements: this will lead to UB.
 pub unsafe trait Storage<N: Scalar, R: Dim, C: Dim = U1>: Debug + Sized {
     /// The static stride of this storage's rows.

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -24,21 +24,25 @@ use abomonation::Abomonation;
 #[repr(C)]
 #[derive(Eq, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-pub struct MatrixVec<N, R: Dim, C: Dim> {
+pub struct VecStorage<N, R: Dim, C: Dim> {
     data: Vec<N>,
     nrows: R,
     ncols: C,
 }
 
-impl<N, R: Dim, C: Dim> MatrixVec<N, R, C> {
+#[deprecated(note="renamed to `VecStorage`")]
+/// Renamed to [VecStorage].
+pub type MatrixVec<N, R, C> = VecStorage<N, R, C>;
+
+impl<N, R: Dim, C: Dim> VecStorage<N, R, C> {
     /// Creates a new dynamic matrix data storage from the given vector and shape.
     #[inline]
-    pub fn new(nrows: R, ncols: C, data: Vec<N>) -> MatrixVec<N, R, C> {
+    pub fn new(nrows: R, ncols: C, data: Vec<N>) -> VecStorage<N, R, C> {
         assert!(
             nrows.value() * ncols.value() == data.len(),
             "Data storage buffer dimension mismatch."
         );
-        MatrixVec {
+        VecStorage {
             data: data,
             nrows: nrows,
             ncols: ncols,
@@ -79,7 +83,7 @@ impl<N, R: Dim, C: Dim> MatrixVec<N, R, C> {
     }
 }
 
-impl<N, R: Dim, C: Dim> Deref for MatrixVec<N, R, C> {
+impl<N, R: Dim, C: Dim> Deref for VecStorage<N, R, C> {
     type Target = Vec<N>;
 
     #[inline]
@@ -88,7 +92,7 @@ impl<N, R: Dim, C: Dim> Deref for MatrixVec<N, R, C> {
     }
 }
 
-impl<N, R: Dim, C: Dim> Into<Vec<N>> for MatrixVec<N, R, C>
+impl<N, R: Dim, C: Dim> Into<Vec<N>> for VecStorage<N, R, C>
 {
     fn into(self) -> Vec<N> {
         self.data
@@ -101,7 +105,7 @@ impl<N, R: Dim, C: Dim> Into<Vec<N>> for MatrixVec<N, R, C>
  * Dynamic − Dynamic
  *
  */
-unsafe impl<N: Scalar, C: Dim> Storage<N, Dynamic, C> for MatrixVec<N, Dynamic, C>
+unsafe impl<N: Scalar, C: Dim> Storage<N, Dynamic, C> for VecStorage<N, Dynamic, C>
 where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
 {
     type RStride = U1;
@@ -145,7 +149,7 @@ where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
     }
 }
 
-unsafe impl<N: Scalar, R: DimName> Storage<N, R, Dynamic> for MatrixVec<N, R, Dynamic>
+unsafe impl<N: Scalar, R: DimName> Storage<N, R, Dynamic> for VecStorage<N, R, Dynamic>
 where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
 {
     type RStride = U1;
@@ -194,7 +198,7 @@ where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
  * StorageMut, ContiguousStorage.
  *
  */
-unsafe impl<N: Scalar, C: Dim> StorageMut<N, Dynamic, C> for MatrixVec<N, Dynamic, C>
+unsafe impl<N: Scalar, C: Dim> StorageMut<N, Dynamic, C> for VecStorage<N, Dynamic, C>
 where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
 {
     #[inline]
@@ -208,13 +212,13 @@ where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
     }
 }
 
-unsafe impl<N: Scalar, C: Dim> ContiguousStorage<N, Dynamic, C> for MatrixVec<N, Dynamic, C> where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
+unsafe impl<N: Scalar, C: Dim> ContiguousStorage<N, Dynamic, C> for VecStorage<N, Dynamic, C> where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
 {}
 
-unsafe impl<N: Scalar, C: Dim> ContiguousStorageMut<N, Dynamic, C> for MatrixVec<N, Dynamic, C> where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
+unsafe impl<N: Scalar, C: Dim> ContiguousStorageMut<N, Dynamic, C> for VecStorage<N, Dynamic, C> where DefaultAllocator: Allocator<N, Dynamic, C, Buffer = Self>
 {}
 
-unsafe impl<N: Scalar, R: DimName> StorageMut<N, R, Dynamic> for MatrixVec<N, R, Dynamic>
+unsafe impl<N: Scalar, R: DimName> StorageMut<N, R, Dynamic> for VecStorage<N, R, Dynamic>
 where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
 {
     #[inline]
@@ -229,7 +233,7 @@ where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
 }
 
 #[cfg(feature = "abomonation-serialize")]
-impl<N: Abomonation, R: Dim, C: Dim> Abomonation for MatrixVec<N, R, C> {
+impl<N: Abomonation, R: Dim, C: Dim> Abomonation for VecStorage<N, R, C> {
     unsafe fn entomb<W: Write>(&self, writer: &mut W) -> IOResult<()> {
         self.data.entomb(writer)
     }
@@ -243,21 +247,21 @@ impl<N: Abomonation, R: Dim, C: Dim> Abomonation for MatrixVec<N, R, C> {
     }
 }
 
-unsafe impl<N: Scalar, R: DimName> ContiguousStorage<N, R, Dynamic> for MatrixVec<N, R, Dynamic> where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
+unsafe impl<N: Scalar, R: DimName> ContiguousStorage<N, R, Dynamic> for VecStorage<N, R, Dynamic> where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
 {}
 
-unsafe impl<N: Scalar, R: DimName> ContiguousStorageMut<N, R, Dynamic> for MatrixVec<N, R, Dynamic> where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
+unsafe impl<N: Scalar, R: DimName> ContiguousStorageMut<N, R, Dynamic> for VecStorage<N, R, Dynamic> where DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>
 {}
 
-impl<N, R: Dim> Extend<N> for MatrixVec<N, R, Dynamic>
+impl<N, R: Dim> Extend<N> for VecStorage<N, R, Dynamic>
 {
-    /// Extends the number of columns of the `MatrixVec` with elements
+    /// Extends the number of columns of the `VecStorage` with elements
     /// from the given iterator.
     ///
     /// # Panics
     /// This function panics if the number of elements yielded by the
     /// given iterator is not a multiple of the number of rows of the
-    /// `MatrixVec`.
+    /// `VecStorage`.
     fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I)
     {
         self.data.extend(iter);
@@ -267,7 +271,7 @@ impl<N, R: Dim> Extend<N> for MatrixVec<N, R, Dynamic>
     }
 }
 
-impl<N, R, RV, SV> Extend<Vector<N, RV, SV>> for MatrixVec<N, R, Dynamic>
+impl<N, R, RV, SV> Extend<Vector<N, RV, SV>> for VecStorage<N, R, Dynamic>
 where
     N: Scalar,
     R: Dim,
@@ -275,13 +279,13 @@ where
     SV: Storage<N, RV>,
     ShapeConstraint: SameNumberOfRows<R, RV>,
 {
-    /// Extends the number of columns of the `MatrixVec` with vectors
+    /// Extends the number of columns of the `VecStorage` with vectors
     /// from the given iterator.
     ///
     /// # Panics
     /// This function panics if the number of rows of each `Vector`
     /// yielded by the iterator is not equal to the number of rows
-    /// of this `MatrixVec`.
+    /// of this `VecStorage`.
     fn extend<I: IntoIterator<Item=Vector<N, RV, SV>>>(&mut self, iter: I)
     {
         let nrows = self.nrows.value();
@@ -296,9 +300,9 @@ where
     }
 }
 
-impl<N> Extend<N> for MatrixVec<N, Dynamic, U1>
+impl<N> Extend<N> for VecStorage<N, Dynamic, U1>
 {
-    /// Extends the number of rows of the `MatrixVec` with elements
+    /// Extends the number of rows of the `VecStorage` with elements
     /// from the given iterator.
     fn extend<I: IntoIterator<Item=N>>(&mut self, iter: I)
     {


### PR DESCRIPTION
This implements the renaming proposed in #470:
 - `MatrixVec` → `VecStorage`
 - `MatrixArray` → `ArrayStorage`

`MatrixVec` and `MatrixArray` remain as deprecated type aliases to `VecStorage` and `ArrayStorage`, respectively, so this may not actually be a breaking change.