### PR TITLE
Rename `unwrap` to `into_inner`.

### DIFF
--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -121,7 +121,7 @@ impl<N: Real> Matrix4<N> {
     /// Creates a new homogeneous matrix for a perspective projection.
     #[inline]
     pub fn new_perspective(aspect: N, fovy: N, znear: N, zfar: N) -> Self {
-        Perspective3::new(aspect, fovy, znear, zfar).unwrap()
+        Perspective3::new(aspect, fovy, znear, zfar).into_inner()
     }
 
     /// Creates an isometry that corresponds to the local frame of an observer standing at the

--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -115,7 +115,7 @@ impl<N: Real> Matrix4<N> {
     /// Creates a new homogeneous matrix for an orthographic projection.
     #[inline]
     pub fn new_orthographic(left: N, right: N, bottom: N, top: N, znear: N, zfar: N) -> Self {
-        Orthographic3::new(left, right, bottom, top, znear, zfar).unwrap()
+        Orthographic3::new(left, right, bottom, top, znear, zfar).into_inner()
     }
 
     /// Creates a new homogeneous matrix for a perspective projection.

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -15,7 +15,7 @@ use alga::linear::NormedSpace;
 
 /// A wrapper that ensures the underlying algebraic entity has a unit norm.
 ///
-/// Use `.as_ref()` or `.unwrap()` to obtain the underlying value by-reference or by-move.
+/// Use `.as_ref()` or `.into_inner()` to obtain the underlying value by-reference or by-move.
 #[repr(transparent)]
 #[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Unit<T> {
@@ -113,6 +113,14 @@ impl<T> Unit<T> {
 
     /// Retrieves the underlying value.
     #[inline]
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+
+    /// Retrieves the underlying value.
+    /// Deprecated: use [Unit::into_inner] instead.
+    #[deprecated(note="use `.into_inner()` instead")]
+    #[inline]
     pub fn unwrap(self) -> T {
         self.value
     }
@@ -143,7 +151,7 @@ where T::Field: RelativeEq
 {
     #[inline]
     fn to_superset(&self) -> T {
-        self.clone().unwrap()
+        self.clone().into_inner()
     }
 
     #[inline]

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -280,8 +280,16 @@ impl<N: Real> Orthographic3<N> {
     ///     0.0,       0.0,       -2.0 / 999.9, -1000.1 / 999.9,
     ///     0.0,       0.0,        0.0,         1.0
     /// );
-    /// assert_eq!(proj.unwrap(), expected);
+    /// assert_eq!(proj.into_inner(), expected);
     /// ```
+    #[inline]
+    pub fn into_inner(self) -> Matrix4<N> {
+        self.matrix
+    }
+
+    /// Retrieves the underlying homogeneous matrix.
+    /// Deprecated: Use [Orthographic3::into_inner] instead.
+    #[deprecated(note="use `.into_inner()` instead")]
     #[inline]
     pub fn unwrap(self) -> Matrix4<N> {
         self.matrix
@@ -725,6 +733,6 @@ where Matrix4<N>: Send
 impl<N: Real> From<Orthographic3<N>> for Matrix4<N> {
     #[inline]
     fn from(orth: Orthographic3<N>) -> Self {
-        orth.unwrap()
+        orth.into_inner()
     }
 }

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -141,6 +141,14 @@ impl<N: Real> Perspective3<N> {
 
     /// Retrieves the underlying homogeneous matrix.
     #[inline]
+    pub fn into_inner(self) -> Matrix4<N> {
+        self.matrix
+    }
+
+    /// Retrieves the underlying homogeneous matrix.
+    /// Deprecated: Use [Perspective3::into_inner] instead.
+    #[deprecated(note="use `.into_inner()` instead")]
+    #[inline]
     pub fn unwrap(self) -> Matrix4<N> {
         self.matrix
     }
@@ -279,6 +287,6 @@ impl<N: Real + Arbitrary> Arbitrary for Perspective3<N> {
 impl<N: Real> From<Perspective3<N>> for Matrix4<N> {
     #[inline]
     fn from(orth: Perspective3<N>) -> Self {
-        orth.unwrap()
+        orth.into_inner()
     }
 }

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -156,7 +156,7 @@ impl<N: Real> Quaternion<N> {
     /// let inv_q = q.try_inverse();
     ///
     /// assert!(inv_q.is_some());
-    /// assert_relative_eq!(inv_q.into_inner() * q, Quaternion::identity());
+    /// assert_relative_eq!(inv_q.unwrap() * q, Quaternion::identity());
     ///
     /// //Non-invertible case
     /// let q = Quaternion::new(0.0, 0.0, 0.0, 0.0);
@@ -914,7 +914,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// let angle = 1.2;
     /// let rot = UnitQuaternion::from_axis_angle(&axis, angle);
     /// let pow = rot.powf(2.0);
-    /// assert_relative_eq!(pow.axis().into_inner(), axis, epsilon = 1.0e-6);
+    /// assert_relative_eq!(pow.axis().unwrap(), axis, epsilon = 1.0e-6);
     /// assert_eq!(pow.angle(), 2.4);
     /// ```
     #[inline]

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -156,7 +156,7 @@ impl<N: Real> Quaternion<N> {
     /// let inv_q = q.try_inverse();
     ///
     /// assert!(inv_q.is_some());
-    /// assert_relative_eq!(inv_q.unwrap() * q, Quaternion::identity());
+    /// assert_relative_eq!(inv_q.into_inner() * q, Quaternion::identity());
     ///
     /// //Non-invertible case
     /// let q = Quaternion::new(0.0, 0.0, 0.0, 0.0);
@@ -747,7 +747,7 @@ impl<N: Real> UnitQuaternion<N> {
         Unit::new_unchecked(Quaternion::from(
             Unit::new_unchecked(self.coords)
                 .slerp(&Unit::new_unchecked(other.coords), t)
-                .unwrap(),
+                .into_inner(),
         ))
     }
 
@@ -771,7 +771,7 @@ impl<N: Real> UnitQuaternion<N> {
     {
         Unit::new_unchecked(self.coords)
             .try_slerp(&Unit::new_unchecked(other.coords), t, epsilon)
-            .map(|q| Unit::new_unchecked(Quaternion::from(q.unwrap())))
+            .map(|q| Unit::new_unchecked(Quaternion::from(q.into_inner())))
     }
 
     /// Compute the conjugate of this unit quaternion in-place.
@@ -837,7 +837,7 @@ impl<N: Real> UnitQuaternion<N> {
     #[inline]
     pub fn scaled_axis(&self) -> Vector3<N> {
         if let Some(axis) = self.axis() {
-            axis.unwrap() * self.angle()
+            axis.into_inner() * self.angle()
         } else {
             Vector3::zero()
         }
@@ -894,7 +894,7 @@ impl<N: Real> UnitQuaternion<N> {
     #[inline]
     pub fn ln(&self) -> Quaternion<N> {
         if let Some(v) = self.axis() {
-            Quaternion::from_parts(N::zero(), v.unwrap() * self.angle())
+            Quaternion::from_parts(N::zero(), v.into_inner() * self.angle())
         } else {
             Quaternion::zero()
         }
@@ -914,7 +914,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// let angle = 1.2;
     /// let rot = UnitQuaternion::from_axis_angle(&axis, angle);
     /// let pow = rot.powf(2.0);
-    /// assert_relative_eq!(pow.axis().unwrap(), axis, epsilon = 1.0e-6);
+    /// assert_relative_eq!(pow.axis().into_inner(), axis, epsilon = 1.0e-6);
     /// assert_eq!(pow.angle(), 2.4);
     /// ```
     #[inline]
@@ -1029,7 +1029,7 @@ impl<N: Real> UnitQuaternion<N> {
 impl<N: Real + fmt::Display> fmt::Display for UnitQuaternion<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(axis) = self.axis() {
-            let axis = axis.unwrap();
+            let axis = axis.into_inner();
             write!(
                 f,
                 "UnitQuaternion angle: {} − axis: ({}, {}, {})",

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -76,7 +76,7 @@ impl<N: Real> Quaternion<N> {
     where SB: Storage<N, U3> {
         let rot = UnitQuaternion::<N>::from_axis_angle(&axis, theta * ::convert(2.0f64));
 
-        rot.unwrap() * scale
+        rot.into_inner() * scale
     }
 
     /// The quaternion multiplicative identity.
@@ -176,7 +176,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// let vec = Vector3::new(4.0, 5.0, 6.0);
     /// let q = UnitQuaternion::from_axis_angle(&axis, angle);
     ///
-    /// assert_eq!(q.axis().unwrap(), axis);
+    /// assert_eq!(q.axis().into_inner(), axis);
     /// assert_eq!(q.angle(), angle);
     /// assert_relative_eq!(q * pt, Point3::new(6.0, 5.0, -4.0), epsilon = 1.0e-6);
     /// assert_relative_eq!(q * vec, Vector3::new(6.0, 5.0, -4.0), epsilon = 1.0e-6);
@@ -244,7 +244,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// let rot = Rotation3::from_axis_angle(&axis, angle);
     /// let q = UnitQuaternion::from_rotation_matrix(&rot);
     /// assert_relative_eq!(q.to_rotation_matrix(), rot, epsilon = 1.0e-6);
-    /// assert_relative_eq!(q.axis().unwrap(), rot.axis().unwrap(), epsilon = 1.0e-6);
+    /// assert_relative_eq!(q.axis().into_inner(), rot.axis().into_inner(), epsilon = 1.0e-6);
     /// assert_relative_eq!(q.angle(), rot.angle(), epsilon = 1.0e-6);
     /// ```
     #[inline]
@@ -306,7 +306,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Vector3, UnitQuaternion};
     /// let a = Vector3::new(1.0, 2.0, 3.0);
     /// let b = Vector3::new(3.0, 1.0, 2.0);
-    /// let q = UnitQuaternion::rotation_between(&a, &b).unwrap();
+    /// let q = UnitQuaternion::rotation_between(&a, &b).into_inner();
     /// assert_relative_eq!(q * a, b);
     /// assert_relative_eq!(q.inverse() * b, a);
     /// ```
@@ -329,8 +329,8 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Vector3, UnitQuaternion};
     /// let a = Vector3::new(1.0, 2.0, 3.0);
     /// let b = Vector3::new(3.0, 1.0, 2.0);
-    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).unwrap();
-    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).unwrap();
+    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).into_inner();
+    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).into_inner();
     /// assert_relative_eq!(q2 * q2 * q2 * q2 * q2 * a, b, epsilon = 1.0e-6);
     /// assert_relative_eq!(q5 * q5 * a, b, epsilon = 1.0e-6);
     /// ```
@@ -365,7 +365,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Unit, Vector3, UnitQuaternion};
     /// let a = Unit::new_normalize(Vector3::new(1.0, 2.0, 3.0));
     /// let b = Unit::new_normalize(Vector3::new(3.0, 1.0, 2.0));
-    /// let q = UnitQuaternion::rotation_between(&a, &b).unwrap();
+    /// let q = UnitQuaternion::rotation_between(&a, &b).into_inner();
     /// assert_relative_eq!(q * a, b);
     /// assert_relative_eq!(q.inverse() * b, a);
     /// ```
@@ -391,8 +391,8 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Unit, Vector3, UnitQuaternion};
     /// let a = Unit::new_normalize(Vector3::new(1.0, 2.0, 3.0));
     /// let b = Unit::new_normalize(Vector3::new(3.0, 1.0, 2.0));
-    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).unwrap();
-    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).unwrap();
+    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).into_inner();
+    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).into_inner();
     /// assert_relative_eq!(q2 * q2 * q2 * q2 * q2 * a, b, epsilon = 1.0e-6);
     /// assert_relative_eq!(q5 * q5 * a, b, epsilon = 1.0e-6);
     /// ```
@@ -701,7 +701,7 @@ mod tests {
         let mut rng = rand::prng::XorShiftRng::from_seed([0xAB; 16]);
         for _ in 0..1000 {
             let x = rng.gen::<UnitQuaternion<f32>>();
-            assert!(relative_eq!(x.unwrap().norm(), 1.0))
+            assert!(relative_eq!(x.into_inner().norm(), 1.0))
         }
     }
 }

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -176,7 +176,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// let vec = Vector3::new(4.0, 5.0, 6.0);
     /// let q = UnitQuaternion::from_axis_angle(&axis, angle);
     ///
-    /// assert_eq!(q.axis().into_inner(), axis);
+    /// assert_eq!(q.axis().unwrap(), axis);
     /// assert_eq!(q.angle(), angle);
     /// assert_relative_eq!(q * pt, Point3::new(6.0, 5.0, -4.0), epsilon = 1.0e-6);
     /// assert_relative_eq!(q * vec, Vector3::new(6.0, 5.0, -4.0), epsilon = 1.0e-6);
@@ -244,7 +244,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// let rot = Rotation3::from_axis_angle(&axis, angle);
     /// let q = UnitQuaternion::from_rotation_matrix(&rot);
     /// assert_relative_eq!(q.to_rotation_matrix(), rot, epsilon = 1.0e-6);
-    /// assert_relative_eq!(q.axis().into_inner(), rot.axis().into_inner(), epsilon = 1.0e-6);
+    /// assert_relative_eq!(q.axis().unwrap(), rot.axis().unwrap(), epsilon = 1.0e-6);
     /// assert_relative_eq!(q.angle(), rot.angle(), epsilon = 1.0e-6);
     /// ```
     #[inline]
@@ -306,7 +306,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Vector3, UnitQuaternion};
     /// let a = Vector3::new(1.0, 2.0, 3.0);
     /// let b = Vector3::new(3.0, 1.0, 2.0);
-    /// let q = UnitQuaternion::rotation_between(&a, &b).into_inner();
+    /// let q = UnitQuaternion::rotation_between(&a, &b).unwrap();
     /// assert_relative_eq!(q * a, b);
     /// assert_relative_eq!(q.inverse() * b, a);
     /// ```
@@ -329,8 +329,8 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Vector3, UnitQuaternion};
     /// let a = Vector3::new(1.0, 2.0, 3.0);
     /// let b = Vector3::new(3.0, 1.0, 2.0);
-    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).into_inner();
-    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).into_inner();
+    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).unwrap();
+    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).unwrap();
     /// assert_relative_eq!(q2 * q2 * q2 * q2 * q2 * a, b, epsilon = 1.0e-6);
     /// assert_relative_eq!(q5 * q5 * a, b, epsilon = 1.0e-6);
     /// ```
@@ -365,7 +365,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Unit, Vector3, UnitQuaternion};
     /// let a = Unit::new_normalize(Vector3::new(1.0, 2.0, 3.0));
     /// let b = Unit::new_normalize(Vector3::new(3.0, 1.0, 2.0));
-    /// let q = UnitQuaternion::rotation_between(&a, &b).into_inner();
+    /// let q = UnitQuaternion::rotation_between(&a, &b).unwrap();
     /// assert_relative_eq!(q * a, b);
     /// assert_relative_eq!(q.inverse() * b, a);
     /// ```
@@ -391,8 +391,8 @@ impl<N: Real> UnitQuaternion<N> {
     /// # use nalgebra::{Unit, Vector3, UnitQuaternion};
     /// let a = Unit::new_normalize(Vector3::new(1.0, 2.0, 3.0));
     /// let b = Unit::new_normalize(Vector3::new(3.0, 1.0, 2.0));
-    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).into_inner();
-    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).into_inner();
+    /// let q2 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.2).unwrap();
+    /// let q5 = UnitQuaternion::scaled_rotation_between(&a, &b, 0.5).unwrap();
     /// assert_relative_eq!(q2 * q2 * q2 * q2 * q2 * a, b, epsilon = 1.0e-6);
     /// assert_relative_eq!(q5 * q5 * a, b, epsilon = 1.0e-6);
     /// ```

--- a/src/geometry/quaternion_conversion.rs
+++ b/src/geometry/quaternion_conversion.rs
@@ -228,7 +228,7 @@ impl<N: Real> From<UnitQuaternion<N>> for Matrix4<N> {
 impl<N: Real> From<UnitQuaternion<N>> for Matrix3<N> {
     #[inline]
     fn from(q: UnitQuaternion<N>) -> Matrix3<N> {
-        q.to_rotation_matrix().unwrap()
+        q.to_rotation_matrix().into_inner()
     }
 }
 

--- a/src/geometry/quaternion_ops.rs
+++ b/src/geometry/quaternion_ops.rs
@@ -469,7 +469,7 @@ quaternion_op_impl!(
     (U4, U1), (U3, U1) for SB: Storage<N, U3> ;
     self: &'a UnitQuaternion<N>, rhs: Unit<Vector<N, U3, SB>>,
     Output = Unit<Vector3<N>> => U3, U4;
-    Unit::new_unchecked(self * rhs.unwrap());
+    Unit::new_unchecked(self * rhs.into_inner());
     'a);
 
 quaternion_op_impl!(
@@ -485,7 +485,7 @@ quaternion_op_impl!(
     (U4, U1), (U3, U1) for SB: Storage<N, U3> ;
     self: UnitQuaternion<N>, rhs: Unit<Vector<N, U3, SB>>,
     Output = Unit<Vector3<N>> => U3, U4;
-    Unit::new_unchecked(self * rhs.unwrap());
+    Unit::new_unchecked(self * rhs.into_inner());
     );
 
 macro_rules! scalar_op_impl(

--- a/src/geometry/reflection.rs
+++ b/src/geometry/reflection.rs
@@ -20,7 +20,7 @@ impl<N: Real, D: Dim, S: Storage<N, D>> Reflection<N, D, S> {
     /// represents a plane that passes through the origin.
     pub fn new(axis: Unit<Vector<N, D, S>>, bias: N) -> Reflection<N, D, S> {
         Reflection {
-            axis: axis.unwrap(),
+            axis: axis.into_inner(),
             bias: bias,
         }
     }

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -154,7 +154,7 @@ where DefaultAllocator: Allocator<N, D, D>
     /// # use nalgebra::{Rotation2, Rotation3, Vector3, Matrix2, Matrix3};
     /// # use std::f32;
     /// let rot = Rotation3::from_axis_angle(&Vector3::z_axis(), f32::consts::FRAC_PI_6);
-    /// let mat = rot.unwrap();
+    /// let mat = rot.into_inner();
     /// let expected = Matrix3::new(0.8660254, -0.5,      0.0,
     ///                             0.5,       0.8660254, 0.0,
     ///                             0.0,       0.0,       1.0);
@@ -162,11 +162,19 @@ where DefaultAllocator: Allocator<N, D, D>
     ///
     ///
     /// let rot = Rotation2::new(f32::consts::FRAC_PI_6);
-    /// let mat = rot.unwrap();
+    /// let mat = rot.into_inner();
     /// let expected = Matrix2::new(0.8660254, -0.5,
     ///                             0.5,       0.8660254);
     /// assert_eq!(mat, expected);
     /// ```
+    #[inline]
+    pub fn into_inner(self) -> MatrixN<N, D> {
+        self.matrix
+    }
+
+    /// Unwraps the underlying matrix.
+    /// Deprecated: Use [Rotation::into_inner] instead.
+    #[deprecated(note="use `.into_inner()` instead")]
     #[inline]
     pub fn unwrap(self) -> MatrixN<N, D> {
         self.matrix

--- a/src/geometry/rotation_conversion.rs
+++ b/src/geometry/rotation_conversion.rs
@@ -227,7 +227,7 @@ impl<N: Real> From<Rotation2<N>> for Matrix3<N> {
 impl<N: Real> From<Rotation2<N>> for Matrix2<N> {
     #[inline]
     fn from(q: Rotation2<N>) -> Matrix2<N> {
-        q.unwrap()
+        q.into_inner()
     }
 }
 
@@ -241,6 +241,6 @@ impl<N: Real> From<Rotation3<N>> for Matrix4<N> {
 impl<N: Real> From<Rotation3<N>> for Matrix3<N> {
     #[inline]
     fn from(q: Rotation3<N>) -> Matrix3<N> {
-        q.unwrap()
+        q.into_inner()
     }
 }

--- a/src/geometry/rotation_ops.rs
+++ b/src/geometry/rotation_ops.rs
@@ -46,9 +46,9 @@ md_impl_all!(
     Mul, mul;
     (D, D), (D, D) for D: DimName;
     self: Rotation<N, D>, right: Rotation<N, D>, Output = Rotation<N, D>;
-    [val val] => Rotation::from_matrix_unchecked(self.unwrap() * right.unwrap());
-    [ref val] => Rotation::from_matrix_unchecked(self.matrix() * right.unwrap());
-    [val ref] => Rotation::from_matrix_unchecked(self.unwrap() * right.matrix());
+    [val val] => Rotation::from_matrix_unchecked(self.into_inner() * right.into_inner());
+    [ref val] => Rotation::from_matrix_unchecked(self.matrix() * right.into_inner());
+    [val ref] => Rotation::from_matrix_unchecked(self.into_inner() * right.matrix());
     [ref ref] => Rotation::from_matrix_unchecked(self.matrix() * right.matrix());
 );
 
@@ -71,9 +71,9 @@ md_impl_all!(
     where DefaultAllocator: Allocator<N, D1, C2>
     where ShapeConstraint: AreMultipliable<D1, D1, R2, C2>;
     self: Rotation<N, D1>, right: Matrix<N, R2, C2, SB>, Output = MatrixMN<N, D1, C2>;
-    [val val] => self.unwrap() * right;
+    [val val] => self.into_inner() * right;
     [ref val] => self.matrix() * right;
-    [val ref] => self.unwrap() * right;
+    [val ref] => self.into_inner() * right;
     [ref ref] => self.matrix() * right;
 );
 
@@ -84,8 +84,8 @@ md_impl_all!(
     where DefaultAllocator: Allocator<N, R1, D2>
     where ShapeConstraint:  AreMultipliable<R1, C1, D2, D2>;
     self: Matrix<N, R1, C1, SA>, right: Rotation<N, D2>, Output = MatrixMN<N, R1, D2>;
-    [val val] => self * right.unwrap();
-    [ref val] => self * right.unwrap();
+    [val val] => self * right.into_inner();
+    [ref val] => self * right.into_inner();
     [val ref] => self * right.matrix();
     [ref ref] => self * right.matrix();
 );
@@ -112,9 +112,9 @@ md_impl_all!(
     where DefaultAllocator: Allocator<N, D>
     where ShapeConstraint:  AreMultipliable<D, D, D, U1>;
     self: Rotation<N, D>, right: Point<N, D>, Output = Point<N, D>;
-    [val val] => self.unwrap() * right;
+    [val val] => self.into_inner() * right;
     [ref val] => self.matrix() * right;
-    [val ref] => self.unwrap() * right;
+    [val ref] => self.into_inner() * right;
     [ref ref] => self.matrix() * right;
 );
 
@@ -125,9 +125,9 @@ md_impl_all!(
     where DefaultAllocator: Allocator<N, D>
     where ShapeConstraint:  AreMultipliable<D, D, D, U1>;
     self: Rotation<N, D>, right: Unit<Vector<N, D, S>>, Output = Unit<VectorN<N, D>>;
-    [val val] => Unit::new_unchecked(self.unwrap() * right.into_inner());
+    [val val] => Unit::new_unchecked(self.into_inner() * right.into_inner());
     [ref val] => Unit::new_unchecked(self.matrix() * right.into_inner());
-    [val ref] => Unit::new_unchecked(self.unwrap() * right.as_ref());
+    [val ref] => Unit::new_unchecked(self.into_inner() * right.as_ref());
     [ref ref] => Unit::new_unchecked(self.matrix() * right.as_ref());
 );
 
@@ -138,7 +138,7 @@ md_assign_impl_all!(
     MulAssign, mul_assign;
     (D, D), (D, D) for D: DimName;
     self: Rotation<N, D>, right: Rotation<N, D>;
-    [val] => self.matrix_mut_unchecked().mul_assign(right.unwrap());
+    [val] => self.matrix_mut_unchecked().mul_assign(right.into_inner());
     [ref] => self.matrix_mut_unchecked().mul_assign(right.matrix());
 );
 
@@ -146,7 +146,7 @@ md_assign_impl_all!(
     DivAssign, div_assign;
     (D, D), (D, D) for D: DimName;
     self: Rotation<N, D>, right: Rotation<N, D>;
-    [val] => self.matrix_mut_unchecked().mul_assign(right.inverse().unwrap());
+    [val] => self.matrix_mut_unchecked().mul_assign(right.inverse().into_inner());
     [ref] => self.matrix_mut_unchecked().mul_assign(right.inverse().matrix());
 );
 
@@ -160,7 +160,7 @@ md_assign_impl_all!(
     MulAssign, mul_assign;
     (R1, C1), (C1, C1) for R1: DimName, C1: DimName;
     self: MatrixMN<N, R1, C1>, right: Rotation<N, C1>;
-    [val] => self.mul_assign(right.unwrap());
+    [val] => self.mul_assign(right.into_inner());
     [ref] => self.mul_assign(right.matrix());
 );
 
@@ -168,6 +168,6 @@ md_assign_impl_all!(
     DivAssign, div_assign;
     (R1, C1), (C1, C1) for R1: DimName, C1: DimName;
     self: MatrixMN<N, R1, C1>, right: Rotation<N, C1>;
-    [val] => self.mul_assign(right.inverse().unwrap());
+    [val] => self.mul_assign(right.inverse().into_inner());
     [ref] => self.mul_assign(right.inverse().matrix());
 );

--- a/src/geometry/rotation_ops.rs
+++ b/src/geometry/rotation_ops.rs
@@ -125,8 +125,8 @@ md_impl_all!(
     where DefaultAllocator: Allocator<N, D>
     where ShapeConstraint:  AreMultipliable<D, D, D, U1>;
     self: Rotation<N, D>, right: Unit<Vector<N, D, S>>, Output = Unit<VectorN<N, D>>;
-    [val val] => Unit::new_unchecked(self.unwrap() * right.unwrap());
-    [ref val] => Unit::new_unchecked(self.matrix() * right.unwrap());
+    [val val] => Unit::new_unchecked(self.unwrap() * right.into_inner());
+    [ref val] => Unit::new_unchecked(self.matrix() * right.into_inner());
     [val ref] => Unit::new_unchecked(self.unwrap() * right.as_ref());
     [ref ref] => Unit::new_unchecked(self.matrix() * right.as_ref());
 );

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -616,7 +616,7 @@ impl<N: Real> Rotation3<N> {
     #[inline]
     pub fn scaled_axis(&self) -> Vector3<N> {
         if let Some(axis) = self.axis() {
-            axis.unwrap() * self.angle()
+            axis.into_inner() * self.angle()
         } else {
             Vector::zero()
         }

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -248,8 +248,16 @@ where DefaultAllocator: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1>>
     ///                      3.0, 4.0, 0.0,
     ///                      0.0, 0.0, 1.0);
     /// let t = Transform2::from_matrix_unchecked(m);
-    /// assert_eq!(t.unwrap(), m);
+    /// assert_eq!(t.into_inner(), m);
     /// ```
+    #[inline]
+    pub fn into_inner(self) -> MatrixN<N, DimNameSum<D, U1>> {
+        self.matrix
+    }
+
+    /// Retrieves the underlying matrix.
+    /// Deprecated: Use [Transform::into_inner] instead.
+    #[deprecated(note="use `.into_inner()` instead")]
     #[inline]
     pub fn unwrap(self) -> MatrixN<N, DimNameSum<D, U1>> {
         self.matrix
@@ -329,7 +337,7 @@ where DefaultAllocator: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1>>
     ///                      3.0, 4.0, 0.0,
     ///                      0.0, 0.0, 1.0);
     /// let t = Transform2::from_matrix_unchecked(m);
-    /// assert_eq!(t.unwrap(), m);
+    /// assert_eq!(t.into_inner(), m);
     /// ```
     #[inline]
     pub fn to_homogeneous(&self) -> MatrixN<N, DimNameSum<D, U1>> {

--- a/src/geometry/transform_ops.rs
+++ b/src/geometry/transform_ops.rs
@@ -159,9 +159,9 @@ md_impl_all!(
     Mul, mul where N: Real;
     (DimNameSum<D, U1>, DimNameSum<D, U1>), (DimNameSum<D, U1>, DimNameSum<D, U1>) for D: DimNameAdd<U1>, CA: TCategoryMul<CB>, CB: TCategory;
     self: Transform<N, D, CA>, rhs: Transform<N, D, CB>, Output = Transform<N, D, CA::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.unwrap());
-    [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.unwrap());
-    [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.matrix());
+    [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.into_inner());
+    [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.into_inner());
+    [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.matrix());
     [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.matrix());
 );
 
@@ -170,9 +170,9 @@ md_impl_all!(
     Mul, mul where N: Real;
     (DimNameSum<D, U1>, DimNameSum<D, U1>), (D, D) for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>;
     self: Transform<N, D, C>, rhs: Rotation<N, D>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
-    [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
 );
 
@@ -181,8 +181,8 @@ md_impl_all!(
     Mul, mul where N: Real;
     (D, D), (DimNameSum<D, U1>, DimNameSum<D, U1>) for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>;
     self: Rotation<N, D>, rhs: Transform<N, D, C>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
     [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 );
@@ -192,9 +192,9 @@ md_impl_all!(
     Mul, mul where N: Real;
     (U4, U4), (U4, U1) for C: TCategoryMul<TAffine>;
     self: Transform<N, U3, C>, rhs: UnitQuaternion<N>, Output = Transform<N, U3, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
-    [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
 );
 
@@ -203,8 +203,8 @@ md_impl_all!(
     Mul, mul where N: Real;
     (U4, U1), (U4, U4) for C: TCategoryMul<TAffine>;
     self: UnitQuaternion<N>, rhs: Transform<N, U3, C>, Output = Transform<N, U3, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
     [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 );
@@ -215,9 +215,9 @@ md_impl_all!(
     (DimNameSum<D, U1>, DimNameSum<D, U1>), (D, U1)
     for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<MatrixN<N, DimNameSum<D, U1>> >;
     self: Transform<N, D, C>, rhs: Isometry<N, D, R>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
-    [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
 );
 
@@ -227,8 +227,8 @@ md_impl_all!(
     (D, U1), (DimNameSum<D, U1>, DimNameSum<D, U1>)
     for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<MatrixN<N, DimNameSum<D, U1>> >;
     self: Isometry<N, D, R>, rhs: Transform<N, D, C>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
     [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 );
@@ -239,9 +239,9 @@ md_impl_all!(
     (DimNameSum<D, U1>, DimNameSum<D, U1>), (D, U1)
     for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<MatrixN<N, DimNameSum<D, U1>> >;
     self: Transform<N, D, C>, rhs: Similarity<N, D, R>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
-    [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
 );
 
@@ -251,8 +251,8 @@ md_impl_all!(
     (D, U1), (DimNameSum<D, U1>, DimNameSum<D, U1>)
     for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<MatrixN<N, DimNameSum<D, U1>> >;
     self: Similarity<N, D, R>, rhs: Transform<N, D, C>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
     [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 );
@@ -270,9 +270,9 @@ md_impl_all!(
     Mul, mul where N: Real;
     (DimNameSum<D, U1>, DimNameSum<D, U1>), (D, U1) for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>;
     self: Transform<N, D, C>, rhs: Translation<N, D>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
-    [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+    [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
 );
 
@@ -282,8 +282,8 @@ md_impl_all!(
     (D, U1), (DimNameSum<D, U1>, DimNameSum<D, U1>)
     for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>;
     self: Translation<N, D>, rhs: Transform<N, D, C>, Output = Transform<N, D, C::Representative>;
-    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+    [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+    [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
     [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 );
@@ -350,9 +350,9 @@ md_impl_all!(
 //          for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<MatrixN<N, DimNameSum<D, U1>> >
 //          where SB::Alloc: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1> >;
 //          self: Transform<N, D, C>, rhs: Isometry<N, D, R>, Output = Transform<N, D, C::Representative>;
-//          [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.inverse().to_homogeneous());
+//          [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.inverse().to_homogeneous());
 //          [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.inverse().to_homogeneous());
-//          [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.inverse().to_homogeneous());
+//          [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.inverse().to_homogeneous());
 //          [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.inverse().to_homogeneous());
 //      );
 
@@ -363,8 +363,8 @@ md_impl_all!(
 //          for D: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<MatrixN<N, DimNameSum<D, U1>> >
 //          where SA::Alloc: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1> >;
 //          self: Isometry<N, D, R>, rhs: Transform<N, D, C>, Output = Transform<N, D, C::Representative>;
-//          [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-//          [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+//          [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+//          [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
 //          [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 //          [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 //      );
@@ -377,9 +377,9 @@ md_impl_all!(
 //          where SB::Alloc: Allocator<N, D, D >
 //          where SB::Alloc: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1> >;
 //          self: Transform<N, D, C>, rhs: Similarity<N, D, R>, Output = Transform<N, D, C::Representative>;
-//          [val val] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+//          [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
 //          [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
-//          [val ref] => Self::Output::from_matrix_unchecked(self.unwrap() * rhs.to_homogeneous());
+//          [val ref] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
 //          [ref ref] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
 //      );
 
@@ -391,8 +391,8 @@ md_impl_all!(
 //          where SA::Alloc: Allocator<N, D, D >
 //          where SA::Alloc: Allocator<N, DimNameSum<D, U1>, DimNameSum<D, U1> >;
 //          self: Similarity<N, D, R>, rhs: Transform<N, D, C>, Output = Transform<N, D, C::Representative>;
-//          [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
-//          [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.unwrap());
+//          [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
+//          [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
 //          [val ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 //          [ref ref] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.matrix());
 //      );
@@ -425,7 +425,7 @@ md_assign_impl_all!(
     MulAssign, mul_assign where N: Real;
     (DimNameSum<D, U1>, DimNameSum<D, U1>), (DimNameSum<D, U1>, DimNameSum<D, U1>) for D: DimNameAdd<U1>, CA: TCategory, CB: SubTCategoryOf<CA>;
     self: Transform<N, D, CA>, rhs: Transform<N, D, CB>;
-    [val] => *self.matrix_mut_unchecked() *= rhs.unwrap();
+    [val] => *self.matrix_mut_unchecked() *= rhs.into_inner();
     [ref] => *self.matrix_mut_unchecked() *= rhs.matrix();
 );
 

--- a/src/geometry/unit_complex.rs
+++ b/src/geometry/unit_complex.rs
@@ -320,6 +320,6 @@ impl<N: Real> From<UnitComplex<N>> for Matrix3<N> {
 impl<N: Real> From<UnitComplex<N>> for Matrix2<N> {
     #[inline]
     fn from(q: UnitComplex<N>) -> Matrix2<N> {
-        q.to_rotation_matrix().unwrap()
+        q.to_rotation_matrix().into_inner()
     }
 }

--- a/src/geometry/unit_complex_ops.rs
+++ b/src/geometry/unit_complex_ops.rs
@@ -50,7 +50,7 @@ impl<N: Real> Mul<UnitComplex<N>> for UnitComplex<N> {
 
     #[inline]
     fn mul(self, rhs: UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.unwrap() * rhs.unwrap())
+        Unit::new_unchecked(self.into_inner() * rhs.into_inner())
     }
 }
 
@@ -59,7 +59,7 @@ impl<'a, N: Real> Mul<UnitComplex<N>> for &'a UnitComplex<N> {
 
     #[inline]
     fn mul(self, rhs: UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.complex() * rhs.unwrap())
+        Unit::new_unchecked(self.complex() * rhs.into_inner())
     }
 }
 
@@ -68,7 +68,7 @@ impl<'b, N: Real> Mul<&'b UnitComplex<N>> for UnitComplex<N> {
 
     #[inline]
     fn mul(self, rhs: &'b UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.unwrap() * rhs.complex())
+        Unit::new_unchecked(self.into_inner() * rhs.complex())
     }
 }
 
@@ -87,7 +87,7 @@ impl<N: Real> Div<UnitComplex<N>> for UnitComplex<N> {
 
     #[inline]
     fn div(self, rhs: UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.unwrap() * rhs.conjugate().unwrap())
+        Unit::new_unchecked(self.into_inner() * rhs.conjugate().into_inner())
     }
 }
 
@@ -96,7 +96,7 @@ impl<'a, N: Real> Div<UnitComplex<N>> for &'a UnitComplex<N> {
 
     #[inline]
     fn div(self, rhs: UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.complex() * rhs.conjugate().unwrap())
+        Unit::new_unchecked(self.complex() * rhs.conjugate().into_inner())
     }
 }
 
@@ -105,7 +105,7 @@ impl<'b, N: Real> Div<&'b UnitComplex<N>> for UnitComplex<N> {
 
     #[inline]
     fn div(self, rhs: &'b UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.unwrap() * rhs.conjugate().unwrap())
+        Unit::new_unchecked(self.into_inner() * rhs.conjugate().into_inner())
     }
 }
 
@@ -114,7 +114,7 @@ impl<'a, 'b, N: Real> Div<&'b UnitComplex<N>> for &'a UnitComplex<N> {
 
     #[inline]
     fn div(self, rhs: &'b UnitComplex<N>) -> UnitComplex<N> {
-        Unit::new_unchecked(self.complex() * rhs.conjugate().unwrap())
+        Unit::new_unchecked(self.complex() * rhs.conjugate().into_inner())
     }
 }
 

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -412,7 +412,7 @@ where
             rot.rotate_rows(&mut m);
 
             if compute_q {
-                let c = rot.unwrap();
+                let c = rot.into_inner();
                 // XXX: we have to build the matrix manually because
                 // rot.to_rotation_matrix().unwrap() causes an ICE.
                 q = Some(MatrixN::from_column_slice_generic(

--- a/tests/geometry/projection.rs
+++ b/tests/geometry/projection.rs
@@ -5,7 +5,7 @@ fn perspective_inverse() {
     let proj = Perspective3::new(800.0 / 600.0, 3.14 / 2.0, 1.0, 1000.0);
     let inv = proj.inverse();
 
-    let id = inv * proj.unwrap();
+    let id = inv * proj.into_inner();
 
     assert!(id.is_identity(1.0e-7));
 }

--- a/tests/geometry/projection.rs
+++ b/tests/geometry/projection.rs
@@ -15,7 +15,7 @@ fn orthographic_inverse() {
     let proj = Orthographic3::new(1.0, 2.0, -3.0, -2.5, 10.0, 900.0);
     let inv = proj.inverse();
 
-    let id = inv * proj.unwrap();
+    let id = inv * proj.into_inner();
 
     assert!(id.is_identity(1.0e-7));
 }


### PR DESCRIPTION
Implements #460 for `Unit`, `Rotation`, `Transform`, `Orthographic3` and `Perspective3`. In all cases, `unwrap()` is retained, but deprecated.