### PR TITLE
`iter::Sum` for `DMatrix`

### DIFF
--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -681,14 +681,14 @@ impl_constructors!(Dynamic, Dynamic;
  * Zero, One, Rand traits.
  *
  */
-impl<N, R: DimName, C: DimName> Zero for MatrixMN<N, R, C>
+impl<N, R: Dim, C: Dim> Zero for MatrixMN<N, R, C>
 where
     N: Scalar + Zero + ClosedAdd,
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
     fn zero() -> Self {
-        Self::from_element(N::zero())
+        Self::zeros_generic(R::default(), C::default())
     }
 
     #[inline]

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -27,6 +27,13 @@ impl Dynamic {
     }
 }
 
+impl Default for Dynamic {
+    /// A dynamic size equal to `0`.
+    fn default() -> Dynamic {
+        Dynamic::new(0)
+    }
+}
+
 #[cfg(feature = "serde-serialize")]
 impl Serialize for Dynamic {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -53,7 +60,7 @@ impl IsNotStaticOne for Dynamic {}
 
 /// Trait implemented by any type that can be used as a dimension. This includes type-level
 /// integers and `Dynamic` (for dimensions not known at compile-time).
-pub trait Dim: Any + Debug + Copy + PartialEq + Send + Sync {
+pub trait Dim: Any + Debug + Default + Copy + PartialEq + Send + Sync {
     #[inline(always)]
     fn is<D: Dim>() -> bool {
         TypeId::of::<Self>() == TypeId::of::<D>()
@@ -237,6 +244,12 @@ impl DimName for U1 {
     }
 }
 
+impl Default for U1 {
+    fn default() -> U1 {
+        U1
+    }
+}
+
 impl NamedDim for typenum::U1 {
     type Name = U1;
 }
@@ -280,6 +293,12 @@ macro_rules! named_dimension(
         }
 
         impl IsNotStaticOne for $D { }
+
+        impl Default for $D {
+            fn default() -> $D {
+                $D
+            }
+        }
     )*}
 );
 
@@ -297,26 +316,26 @@ named_dimension!(
 
 // For values greater than U1023, just use the typenum binary representation directly.
 impl<
-        A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        C: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        D: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        E: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        F: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        G: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        A: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        C: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        D: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        E: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        F: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        G: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
     > NamedDim for UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, A>, B>, C>, D>, E>, F>, G>
 {
     type Name = Self;
 }
 
 impl<
-        A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        C: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        D: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        E: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        F: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        G: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        A: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        C: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        D: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        E: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        F: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        G: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
     > Dim for UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, A>, B>, C>, D>, E>, F>, G>
 {
     #[inline]
@@ -337,13 +356,13 @@ impl<
 }
 
 impl<
-        A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        C: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        D: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        E: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        F: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        G: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        A: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        C: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        D: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        E: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        F: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        G: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
     > DimName for UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, A>, B>, C>, D>, E>, F>, G>
 {
     type Value = Self;
@@ -355,24 +374,24 @@ impl<
 }
 
 impl<
-        A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        C: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        D: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        E: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        F: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        G: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        A: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        C: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        D: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        E: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        F: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
+        G: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync,
     > IsNotStaticOne
     for UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, A>, B>, C>, D>, E>, F>, G>
 {}
 
-impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> NamedDim
+impl<U: Unsigned + DimName, B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync> NamedDim
     for UInt<U, B>
 {
     type Name = UInt<U, B>;
 }
 
-impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> Dim
+impl<U: Unsigned + DimName, B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync> Dim
     for UInt<U, B>
 {
     #[inline]
@@ -392,7 +411,7 @@ impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Syn
     }
 }
 
-impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> DimName
+impl<U: Unsigned + DimName, B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync> DimName
     for UInt<U, B>
 {
     type Value = UInt<U, B>;
@@ -403,6 +422,6 @@ impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Syn
     }
 }
 
-impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> IsNotStaticOne
+impl<U: Unsigned + DimName, B: Bit + Any + Debug + Default + Copy + PartialEq + Send + Sync> IsNotStaticOne
     for UInt<U, B>
 {}

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -395,7 +395,7 @@ where
     /// If the sequence is empty, a zero matrix is produced in which any dynamic dimensions default to size 0.
     fn sum<I: Iterator<Item = &'a MatrixMN<N, R, C>>>(mut iter: I) -> MatrixMN<N, R, C> {
         iter.next()
-            .map(|first| iter.fold(first.to_owned(), Add::add))
+            .map(|first| iter.fold(first.clone(), Add::add))
             .unwrap_or(MatrixMN::zero())
     }
 }

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -374,23 +374,29 @@ componentwise_binop_impl!(Sub, sub, ClosedSub;
                           SubAssign, sub_assign, sub_assign_statically_unchecked, sub_assign_statically_unchecked_mut;
                           sub_to, sub_to_statically_unchecked);
 
-impl<N, R: DimName, C: DimName> iter::Sum for MatrixMN<N, R, C>
+impl<N, R: Dim, C: Dim> iter::Sum for MatrixMN<N, R, C>
 where
     N: Scalar + ClosedAdd + Zero,
     DefaultAllocator: Allocator<N, R, C>,
 {
-    fn sum<I: Iterator<Item = MatrixMN<N, R, C>>>(iter: I) -> MatrixMN<N, R, C> {
-        iter.fold(Matrix::zero(), |acc, x| acc + x)
+    /// If the sequence is empty, a zero matrix is produced in which any dynamic dimensions default to size 0.
+    fn sum<I: Iterator<Item = MatrixMN<N, R, C>>>(mut iter: I) -> MatrixMN<N, R, C> {
+        iter.next()
+            .map(|first| iter.fold(first, Add::add))
+            .unwrap_or(MatrixMN::zero())
     }
 }
 
-impl<'a, N, R: DimName, C: DimName> iter::Sum<&'a MatrixMN<N, R, C>> for MatrixMN<N, R, C>
+impl<'a, N, R: Dim, C: Dim> iter::Sum<&'a MatrixMN<N, R, C>> for MatrixMN<N, R, C>
 where
     N: Scalar + ClosedAdd + Zero,
     DefaultAllocator: Allocator<N, R, C>,
 {
-    fn sum<I: Iterator<Item = &'a MatrixMN<N, R, C>>>(iter: I) -> MatrixMN<N, R, C> {
-        iter.fold(Matrix::zero(), |acc, x| acc + x)
+    /// If the sequence is empty, a zero matrix is produced in which any dynamic dimensions default to size 0.
+    fn sum<I: Iterator<Item = &'a MatrixMN<N, R, C>>>(mut iter: I) -> MatrixMN<N, R, C> {
+        iter.next()
+            .map(|first| iter.fold(first.to_owned(), Add::add))
+            .unwrap_or(MatrixMN::zero())
     }
 }
 


### PR DESCRIPTION
This is one potential way to address #514. It tackles the problem in three steps:
1. The foundation of this approach is to [introduce](https://github.com/rustsim/nalgebra/commit/ccdd393700e83e3093b1986e67a9778c18a2b1cc) a notion of `Default` for dimensions. Statically known dimensions default to their value (this is already the behavior of the `Default` implementation provided by typenum). The `Default` of a `Dynamic` dimension is 0.
2. Using this, we can [then](https://github.com/rustsim/nalgebra/commit/1dd762d17460ec7fa6765010ed84bd9e29b0c293) lift `DimName` requirements on `Matrix` constructors that required them; any dynamic dimensions simply default to zero size.
3. [Finally](https://github.com/rustsim/nalgebra/commit/d60f138f626bc8faa8bc2eb37536435e7fdc6bc9), we can lift the `DimName` requirements on functions that used these constructors, like the implementation of `iter::Sum`.

This PR only lifts the `DimName` requirement on `iter::Sum`, but the approach is broadly applicable and we can use it to lift `DimName` requirements in many parts of nalgebra.