### PR TITLE
Transcendentals2

### DIFF
--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -124,6 +124,12 @@ impl<N: Real> Quaternion<N> {
         Self::from(self.coords.normalize())
     }
 
+    /// The imaginary part of this quaternion.
+    #[inline]
+    pub fn imag(&self) -> Vector3<N> {
+        self.coords.xyz()
+    }
+
     /// The conjugate of this quaternion.
     ///
     /// # Example
@@ -135,13 +141,7 @@ impl<N: Real> Quaternion<N> {
     /// ```
     #[inline]
     pub fn conjugate(&self) -> Self {
-        let v = Vector4::new(
-            -self.coords[0],
-            -self.coords[1],
-            -self.coords[2],
-            self.coords[3],
-        );
-        Self::from(v)
+        Self::from_parts(self.w, -self.imag())
     }
 
     /// Inverts this quaternion if it is not zero.

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -21,6 +21,27 @@ use base::{Matrix3, MatrixN, MatrixSlice, MatrixSliceMut, Unit, Vector3, Vector4
 
 use geometry::Rotation;
 
+/// Calculates the cardinal sine function
+#[inline]
+fn sinc<N: Real>(v: N) -> N {
+    if v == N::zero() {
+        N::zero()
+    }
+    else {
+        v.sin() / v
+    }
+}
+
+#[inline]
+fn sinhc<N: Real>(v: N) -> N {
+    if v == N::zero() {
+        N::zero()
+    }
+    else {
+        v.sinh() / v
+    }
+}
+
 /// A quaternion. See the type alias `UnitQuaternion = Unit<Quaternion>` for a quaternion
 /// that may be used as a rotation.
 #[repr(C)]
@@ -505,6 +526,22 @@ impl<N: Real> Quaternion<N> {
     #[inline]
     pub fn normalize_mut(&mut self) -> N {
         self.coords.normalize_mut()
+    }
+
+       /// Calculates quaternionic sin
+    #[inline]
+    pub fn cos(&self) -> Self {
+        let z = self.imag().magnitude();
+        let w = -self.w.sin() * sinhc(z);
+        Self::from_parts(self.w.cos() * z.cosh(), self.imag() * w)
+    }
+
+    /// Calculates quaternionic sin
+    #[inline]
+    pub fn sin(&self) -> Self {
+        let z = self.imag().magnitude();
+        let w = self.w.cos() * sinhc(z);
+        Self::from_parts(self.w.sin() * z.cosh(), self.imag() * w)
     }
 }
 

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -528,7 +528,7 @@ impl<N: Real> Quaternion<N> {
         self.coords.normalize_mut()
     }
 
-       /// Calculates quaternionic sin
+    /// Calculates quaternionic sin
     #[inline]
     pub fn cos(&self) -> Self {
         let z = self.imag().magnitude();


### PR DESCRIPTION
Based on #551, adds sin and cos. Implementations are based on the boost implementation

https://www.boost.org/doc/libs/1_63_0/boost/math/quaternion.hpp
