### PR TITLE
Fix matrix slerp function

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1480,6 +1480,19 @@ impl<N: Scalar + Zero + One + ClosedAdd + ClosedSub + ClosedMul, D: Dim, S: Stor
 
 impl<N: Real, D: Dim, S: Storage<N, D>> Unit<Vector<N, D, S>> {
     /// Computes the spherical linear interpolation between two unit vectors.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::geometry::UnitQuaternion;
+    ///
+    /// let q1 = UnitQuaternion::from_euler_angles(std::f32::consts::FRAC_PI_4, 0.0, 0.0);
+    /// let q2 = UnitQuaternion::from_euler_angles(-std::f32::consts::PI, 0.0, 0.0);
+    ///
+    /// let q = q1.slerp(&q2, 1.0 / 3.0);
+    ///
+    /// assert_eq!(q.euler_angles(), (std::f32::consts::FRAC_PI_2, 0.0, 0.0));
+    /// ```
     pub fn slerp<S2: Storage<N, D>>(
         &self,
         rhs: &Unit<Vector<N, D, S2>>,

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1513,7 +1513,7 @@ impl<N: Real, D: Dim, S: Storage<N, D>> Unit<Vector<N, D, S>> {
             return Some(Unit::new_unchecked(self.clone_owned()));
         }
 
-        let hang = c_hang.acos();
+        let hang = c_hang.abs().acos();
         let s_hang = (N::one() - c_hang * c_hang).sqrt();
 
         // FIXME: what if s_hang is 0.0 ? The result is not well-defined.
@@ -1522,7 +1522,7 @@ impl<N: Real, D: Dim, S: Storage<N, D>> Unit<Vector<N, D, S>> {
         } else {
             let ta = ((N::one() - t) * hang).sin() / s_hang;
             let tb = (t * hang).sin() / s_hang;
-            let res = &**self * ta + &**rhs * tb;
+            let res = &**self * ta + &**rhs * tb * c_hang.signum();
 
             Some(Unit::new_unchecked(res))
         }


### PR DESCRIPTION
I'm currently using the slerp function to interpolate between frames in a skeletal animation,

Here is the actual result:
![bugged](https://user-images.githubusercontent.com/673101/54865486-6b143480-4d66-11e9-9faf-2cf508ff815b.gif)

Comparing the nalgebra slerp with the gl-matrix slerp (which worked fine on the same animation), I noticed [some differences](https://github.com/toji/gl-matrix/blob/master/src/quat.js#L210-L216) with the nalgebra  implementation.

Same animation after the fix:
![working](https://user-images.githubusercontent.com/673101/54865774-04454a00-4d6b-11e9-82f5-57c6f779c734.gif)

Let me know if you'd like some test around this case

