### PR TITLE
Allow the removal of multiple rows/columns given an array of indices.…

### DIFF
--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -308,7 +308,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     }
 
     /// Removes all columns in `indices`   
-    #[inline]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn remove_columns_at(self, indices: &[usize]) -> MatrixMN<N, R, Dynamic>
     where
         C: DimSub<Dynamic, Output = Dynamic>,
@@ -346,7 +346,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     }
 
     /// Removes all columns in `indices`   
-    #[inline]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn remove_rows_at(self, indices: &[usize]) -> MatrixMN<N, Dynamic, C>
     where
         R: DimSub<Dynamic, Output = Dynamic>,

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -315,12 +315,11 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Reallocator<N, R, C, R, Dynamic>,
     {
         let mut m = self.into_owned();
-        let mut v: Vec<usize> = indices.to_vec();
         let (nrows, ncols) = m.data.shape();
         let mut offset: usize = 0;
         let mut target: usize = 0;
         while offset + target < ncols.value() {
-            if v.contains(&(target + offset)) {
+            if indices.contains(&(target + offset)) {
                 offset += 1;
             } else {
                 unsafe {
@@ -339,26 +338,25 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         unsafe {
             Matrix::from_data(DefaultAllocator::reallocate_copy(
                 nrows,
-                ncols.sub(Dynamic::from_usize(v.len())),
+                ncols.sub(Dynamic::from_usize(offset)),
                 m.data,
             ))
         }
     }
 
-    /// Removes all columns in `indices`   
+    /// Removes all rows in `indices`   
     #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn remove_rows_at(self, indices: &[usize]) -> MatrixMN<N, Dynamic, C>
     where
         R: DimSub<Dynamic, Output = Dynamic>,
         DefaultAllocator: Reallocator<N, R, C, Dynamic, C>,
-    {
+    {        
         let mut m = self.into_owned();
-        let mut v: Vec<usize> = indices.to_vec();
         let (nrows, ncols) = m.data.shape();
         let mut offset: usize = 0;
         let mut target: usize = 0;
         while offset + target < nrows.value() * ncols.value() {
-            if v.contains(&((target + offset) % nrows.value())) {
+            if indices.contains(&((target + offset) % nrows.value())) {
                 offset += 1;
             } else {
                 unsafe {
@@ -373,7 +371,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
 
         unsafe {
             Matrix::from_data(DefaultAllocator::reallocate_copy(
-                nrows.sub(Dynamic::from_usize(v.len())),
+                nrows.sub(Dynamic::from_usize(offset / ncols.value ())),
                 ncols,
                 m.data,
             ))

--- a/tests/core/edition.rs
+++ b/tests/core/edition.rs
@@ -260,6 +260,63 @@ fn remove_columns() {
     assert!(computed.eq(&expected2));
 }
 
+#[test]
+fn remove_columns_at() {
+    let m = DMatrix::from_row_slice(5, 5, &[
+        11, 12, 13, 14, 15,
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    let expected1 = DMatrix::from_row_slice(5, 4, &[
+        12, 13, 14, 15,
+        22, 23, 24, 25,
+        32, 33, 34, 35,
+        42, 43, 44, 45,
+        52, 53, 54, 55
+    ]);
+
+    assert_eq!(m.remove_columns_at(&[0]), expected1);
+
+    let m = DMatrix::from_row_slice(5, 5, &[
+        11, 12, 13, 14, 15,
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    let expected2 = DMatrix::from_row_slice(5, 3, &[
+        11, 13, 15,
+        21, 23, 25,
+        31, 33, 35,
+        41, 43, 45,
+        51, 53, 55
+    ]);
+    
+    assert_eq!(m.remove_columns_at(&[1,3]), expected2);
+
+    let m = DMatrix::from_row_slice(5, 5, &[
+        11, 12, 13, 14, 15,
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    let expected3 = DMatrix::from_row_slice(5, 2, &[
+        12, 13,
+        22, 23,
+        32, 33,
+        42, 43,
+        52, 53, 
+    ]);
+
+    assert_eq!(m.remove_columns_at(&[0,3,4]), expected3);
+}
+
 
 #[test]
 fn remove_rows() {
@@ -314,6 +371,57 @@ fn remove_rows() {
     // The following is just to verify that the return type dimensions is correctly inferred.
     let computed: Matrix<_, Dynamic, U3, _> = m.remove_rows(3, 2);
     assert!(computed.eq(&expected2));
+}
+
+#[test]
+fn remove_rows_at() {
+    let m = DMatrix::from_row_slice(5, 5, &[
+        11, 12, 13, 14, 15,
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    let expected1 = DMatrix::from_row_slice(4, 5, &[
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    assert_eq!(m.remove_rows_at(&[0]), expected1);
+
+    let m = DMatrix::from_row_slice(5, 5, &[
+        11, 12, 13, 14, 15,
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    let expected2 = DMatrix::from_row_slice(3, 5, &[
+        11, 12, 13, 14, 15,
+        31, 32, 33, 34, 35,
+        51, 52, 53, 54, 55
+    ]);
+    
+    assert_eq!(m.remove_rows_at(&[1,3]), expected2);
+
+    let m = DMatrix::from_row_slice(5, 5, &[
+        11, 12, 13, 14, 15,
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35,
+        41, 42, 43, 44, 45,
+        51, 52, 53, 54, 55
+    ]);
+
+    let expected3 = DMatrix::from_row_slice(2, 5, &[
+        21, 22, 23, 24, 25,
+        31, 32, 33, 34, 35
+    ]);
+
+    assert_eq!(m.remove_rows_at(&[0,3,4]), expected3);
 }
 
 


### PR DESCRIPTION
fixes #530

The initial plan was to iteratively remove rows/columns one by one. That didn't work out due to the way nalgebra handles types. 
I therefore opted for manipulating the data directly which has the downside of introducing even more unsafe (and less readable) code but the upside of a better runtime (O(m x n) for a m x n matrix).