### PR TITLE
MatrixSliceMutMN: prevent aliased indices.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ generic-array  = "0.12"
 rand           = { version = "0.6", default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
+num-rational   = { version = "0.2", default-features = false }
 approx         = { version = "0.3", default-features = false }
 alga           = { version = "0.9", default-features = false }
 matrixmultiply = { version = "0.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ extern crate generic_array;
 extern crate matrixmultiply;
 extern crate num_complex;
 extern crate num_traits as num;
+extern crate num_rational;
 extern crate rand;
 extern crate typenum;
 


### PR DESCRIPTION
Fixes #486.

The assertion is structured in a way that rules out false-positives. Each branch of the match arm ends in an assertion in the form:
```rust
index(i₀, j₀) != index(i₁, j₁)
```
If this expression evaluates to false, then `(i₀, j₀)` and `(i₁, j₁)` are, necessarily, examples of indices that will alias to the same linear index.

At a glance, it's a little less obvious that this assertion won't produce false-negatives. (This isn't as alarming as the possibility of a false-positive, since the current false-negative rate is 100%.) [The result of the assertion exactly matches the results of an exhaustive search for all combinations of rows, columns, row strides, and column strides ranging from 0 to 10.](https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=7456bc83f93ed6e9bbf1daf27f27e672)


<small>Thanks to [@hwayne](https://github.com/hwayne) for the insight that in the non-trivial case, the aliased indices relate to the gcd of row and column stride!</small>
