### PR TITLE
Derive Copy, Eq, and Hash for Quaternion.

### DIFF
--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -968,6 +968,28 @@ impl<N: RealField> UnitQuaternion<N> {
         self.conjugate()
     }
 
+    /// Check if the quaternion represents the same rotation as another.
+    ///
+    /// Returns true when `q1 == q2`, or when `q1 == -q2`, to account for the
+    /// double-covering of S², i.e. q = -q.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::{Unit, UnitQuaternion, Quaternion};
+    /// let q1 = Unit::new_normalize(Quaternion::new(0.6, 0.8, 0.0, 0.0));
+    /// let q2 = Unit::new_normalize(Quaternion::new(-0.6, -0.8, 0.0, 0.0));
+    /// assert!(q1.eq_rotation(&q1));
+    /// assert!(q1.eq_rotation(&q2));
+    /// assert!(q2.eq_rotation(&q1));
+    /// assert!(!q1.eq_rotation(&UnitQuaternion::identity()));
+    /// ```
+    #[inline]
+    pub fn eq_rotation(&self, other: &Self) -> bool {
+        self.coords == other.coords ||
+        self.coords.iter().zip(&other.coords).all(|(a, b)| *a == -*b)
+    }
+
+
     /// The rotation angle needed to make `self` and `other` coincide.
     ///
     /// # Example

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -1,7 +1,6 @@
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use num::Zero;
 use std::fmt;
-use std::hash;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
@@ -24,7 +23,7 @@ use crate::geometry::{Point3, Rotation};
 /// A quaternion. See the type alias `UnitQuaternion = Unit<Quaternion>` for a quaternion
 /// that may be used as a rotation.
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Quaternion<N: RealField> {
     /// This quaternion as a 4D vector of coordinates in the `[ x, y, z, w ]` storage order.
     pub coords: Vector4<N>,
@@ -44,31 +43,6 @@ where Vector4<N>: Abomonation
 
     unsafe fn exhume<'a, 'b>(&'a mut self, bytes: &'b mut [u8]) -> Option<&'b mut [u8]> {
         self.coords.exhume(bytes)
-    }
-}
-
-impl<N: RealField + Eq> Eq for Quaternion<N> {}
-
-impl<N: RealField> PartialEq for Quaternion<N> {
-    fn eq(&self, rhs: &Self) -> bool {
-        self.coords == rhs.coords ||
-        // Account for the double-covering of S², i.e. q = -q
-        self.as_vector().iter().zip(rhs.as_vector().iter()).all(|(a, b)| *a == -*b)
-    }
-}
-
-impl<N: RealField + hash::Hash> hash::Hash for Quaternion<N> {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.coords.hash(state)
-    }
-}
-
-impl<N: RealField> Copy for Quaternion<N> {}
-
-impl<N: RealField> Clone for Quaternion<N> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self::from(self.coords.clone())
     }
 }
 

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -835,9 +835,7 @@ impl<N: RealField + AbsDiffEq<Epsilon = N>> AbsDiffEq for Quaternion<N> {
 
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.as_vector().abs_diff_eq(other.as_vector(), epsilon) ||
-        // Account for the double-covering of S², i.e. q = -q
-        self.as_vector().iter().zip(other.as_vector().iter()).all(|(a, b)| a.abs_diff_eq(&-*b, epsilon))
+        self.as_vector().abs_diff_eq(other.as_vector(), epsilon)
     }
 }
 
@@ -855,9 +853,7 @@ impl<N: RealField + RelativeEq<Epsilon = N>> RelativeEq for Quaternion<N> {
         max_relative: Self::Epsilon,
     ) -> bool
     {
-        self.as_vector().relative_eq(other.as_vector(), epsilon, max_relative) ||
-        // Account for the double-covering of S², i.e. q = -q
-        self.as_vector().iter().zip(other.as_vector().iter()).all(|(a, b)| a.relative_eq(&-*b, epsilon, max_relative))
+        self.as_vector().relative_eq(other.as_vector(), epsilon, max_relative)
     }
 }
 
@@ -869,9 +865,7 @@ impl<N: RealField + UlpsEq<Epsilon = N>> UlpsEq for Quaternion<N> {
 
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
-        self.as_vector().ulps_eq(other.as_vector(), epsilon, max_ulps) ||
-        // Account for the double-covering of S², i.e. q = -q.
-        self.as_vector().iter().zip(other.as_vector().iter()).all(|(a, b)| a.ulps_eq(&-*b, epsilon, max_ulps))
+        self.as_vector().ulps_eq(other.as_vector(), epsilon, max_ulps)
     }
 }
 

--- a/tests/geometry/quaternion.rs
+++ b/tests/geometry/quaternion.rs
@@ -110,7 +110,7 @@ quickcheck!(
     fn unit_quaternion_double_covering(q: UnitQuaternion<f64>) -> bool {
         let mq = -q;
 
-        mq == q && mq.angle() == q.angle() && mq.axis() == q.axis()
+        mq.eq_rotation(&q) && mq.angle() == q.angle() && mq.axis() == q.axis()
     }
 
     // Test that all operators (incl. all combinations of references) work.


### PR DESCRIPTION
They were implemented manually.

Eq was implemented in such a way that -q was considered equal to q,
probably because they represent the same rotation. They are, however,
not equal quaternions. Because of this error, the implementation of Hash
was not compatible with the implementation of Eq. This fixes that.

Fixes #583.