### PR TITLE
Fix incorrect documentation from `s/Real/&Field`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 **nalgebra** is a linear algebra library written for Rust targeting:
 
 * General-purpose linear algebra (still lacks a lot of features…)
-* RealField time computer graphics.
-* RealField time computer physics.
+* Real-time computer graphics.
+* Real-time computer physics.
 
 ## Using **nalgebra**
 You will need the last stable build of the [rust compiler](http://www.rust-lang.org)


### PR DESCRIPTION
I assume that you did a sed over the entire project, forgetting about the fact that "Real" is also used within the documentation. I haven't looked for other uses of "Real" other than this in the documentation.