### PR TITLE
Fix for nostd builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ io = [ "pest", "pest_derive" ]
 [dependencies]
 typenum        = "1.10"
 generic-array  = "0.12"
-rand           = { version = "0.6", default-features = false }
+rand           = { version = "0.5", default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
 num-rational   = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ io = [ "pest", "pest_derive" ]
 [dependencies]
 typenum        = "1.10"
 generic-array  = "0.12"
-rand           = { version = "0.5", default-features = false }
+rand           = { version = "0.6", default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
 num-rational   = { version = "0.2", default-features = false }

--- a/nalgebra-glm/src/common.rs
+++ b/nalgebra-glm/src/common.rs
@@ -1,6 +1,6 @@
 use na::{self, DefaultAllocator, RealField};
 use num::FromPrimitive;
-use std::mem;
+use core::mem;
 
 use crate::aliases::{TMat, TVec};
 use crate::traits::{Alloc, Dimension, Number};


### PR DESCRIPTION
1. Downgraded rand for version 0.5 to avoid compilations errors with rand_jitter crate;
2. Changed std::mem to core::mem, to allow glm to compile with nostd. (Maybe it will need a cfg to switch between the two)
