### PR TITLE
Update lapack-src dependency.

### DIFF
--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -30,7 +30,7 @@ alga          = { version = "0.9", default-features = false }
 serde         = { version = "1.0", optional = true }
 serde_derive  = { version = "1.0", optional = true }
 lapack        = { version = "0.16", default-features = false }
-lapack-src    = { version = "0.2", default-features = false }
+lapack-src    = { version = "0.3", default-features = false }
 # clippy = "*"
 
 [dev-dependencies]


### PR DESCRIPTION
This was just published and updates its own dependencies which
removes some dependencies on old versions of rand, rust-crypto,
and other things.