### PR TITLE
Update generic-array dep.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ io = [ "pest", "pest_derive" ]
 
 [dependencies]
 typenum        = "1.10"
-generic-array  = "0.12"
+generic-array  = "0.13"
 rand           = { version = "0.6", default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }


### PR DESCRIPTION
This update requires Rust 1.30.1 or later.