### PR TITLE
Make rand dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ path = "src/lib.rs"
 
 [features]
 default         = [ "std" ]
-std             = [ "matrixmultiply", "rand/std", "alga/std" ]
+std             = [ "matrixmultiply", "alga/std", "rand/std" ]
+std-no-rand     = [ "matrixmultiply", "alga/std" ]
 stdweb          = [ "rand/stdweb" ]
-arbitrary       = [ "quickcheck" ]
+stdweb-no-rand  = [ ]
+arbitrary       = [ "quickcheck", "rand" ]
 serde-serialize = [ "serde", "serde_derive", "num-complex/serde" ]
 abomonation-serialize = [ "abomonation" ]
 sparse = [ ]
@@ -34,7 +36,6 @@ io = [ "pest", "pest_derive" ]
 [dependencies]
 typenum        = "1.10"
 generic-array  = "0.12"
-rand           = { version = "0.6", default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
 num-rational   = { version = "0.2", default-features = false }
@@ -46,6 +47,7 @@ serde_derive   = { version = "1.0", optional = true }
 abomonation    = { version = "0.7", optional = true }
 mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "0.8", optional = true }
+rand           = { version = "0.6", optional = true, default-features = false }
 pest           = { version = "2.0", optional = true }
 pest_derive    = { version = "2.0", optional = true }
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,6 +5,7 @@ set -ev
 if [ -z "$NO_STD" ]; then
     if [ -z "$LAPACK" ]; then
         cargo build --verbose -p nalgebra;
+        cargo build --verbose -p nalgebra --no-default-features --features "std-no-rand";
         cargo build --verbose -p nalgebra --features "arbitrary";
         cargo build --verbose -p nalgebra --features "mint";
         cargo build --verbose -p nalgebra --features "alloc";

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -4,9 +4,12 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::{Bounded, One, Zero};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
-#[cfg(feature = "std")]
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
+#[cfg(all(feature = "std", feature = "rand"))]
 use rand::{self, distributions::StandardNormal};
 use std::iter;
 use typenum::{self, Cmp, Greater};
@@ -240,7 +243,7 @@ where DefaultAllocator: Allocator<N, R, C>
 
     /// Creates a matrix filled with random values.
     #[inline]
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", feature = "rand"))]
     pub fn new_random_generic(nrows: R, ncols: C) -> Self
     where Standard: Distribution<N> {
         Self::from_fn_generic(nrows, ncols, |_, _| rand::random())
@@ -248,6 +251,7 @@ where DefaultAllocator: Allocator<N, R, C>
 
     /// Creates a matrix filled with random values from the given distribution.
     #[inline]
+    #[cfg(feature = "rand")]
     pub fn from_distribution_generic<Distr: Distribution<N> + ?Sized, G: Rng + ?Sized>(
         nrows: R,
         ncols: C,
@@ -548,6 +552,7 @@ macro_rules! impl_constructors(
 
             /// Creates a matrix or vector filled with random values from the given distribution.
             #[inline]
+            #[cfg(feature = "rand")]
             pub fn from_distribution<Distr: Distribution<N> + ?Sized, G: Rng + ?Sized>(
                 $($args: usize,)*
                 distribution: &Distr,
@@ -557,6 +562,7 @@ macro_rules! impl_constructors(
             }
         }
 
+        #[cfg(all(feature = "rand", feature = "std"))]
         impl<N: Scalar, $($DimIdent: $DimBound, )*> MatrixMN<N $(, $Dims)*>
             where
             DefaultAllocator: Allocator<N $(, $Dims)*>,
@@ -564,7 +570,6 @@ macro_rules! impl_constructors(
 
             /// Creates a matrix filled with random values.
             #[inline]
-            #[cfg(feature = "std")]
             pub fn new_random($($args: usize),*) -> Self {
                 Self::new_random_generic($($gargs),*)
             }
@@ -760,6 +765,7 @@ where
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: Scalar, R: Dim, C: Dim> Distribution<MatrixMN<N, R, C>> for Standard
 where
     DefaultAllocator: Allocator<N, R, C>,
@@ -794,7 +800,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "rand"))]
 impl<N: RealField, D: DimName> Distribution<Unit<VectorN<N, D>>> for Standard
 where
     DefaultAllocator: Allocator<N, D>,

--- a/src/base/helper.rs
+++ b/src/base/helper.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 /// Simple helper function for rejection sampling
 #[cfg(feature = "arbitrary")]
@@ -15,6 +18,7 @@ pub fn reject<G: Gen, F: FnMut(&T) -> bool, T: Arbitrary>(g: &mut G, f: F) -> T 
         .unwrap()
 }
 
+#[cfg(feature = "rand")]
 #[doc(hidden)]
 #[inline]
 pub fn reject_rand<G: Rng + ?Sized, F: FnMut(&T) -> bool, T>(g: &mut G, f: F) -> T

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -4,8 +4,11 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::One;
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use alga::general::RealField;
 use alga::linear::Rotation as AlgaRotation;
@@ -75,6 +78,7 @@ where DefaultAllocator: Allocator<N, D>
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField, D: DimName, R> Distribution<Isometry<N, D, R>> for Standard
 where
     R: AlgaRotation<Point<N, D>>,

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 #[cfg(feature = "serde-serialize")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -10,6 +13,7 @@ use std::mem;
 use alga::general::RealField;
 
 use crate::base::dimension::U3;
+#[cfg(feature = "rand")]
 use crate::base::helper;
 use crate::base::storage::Storage;
 use crate::base::{Matrix4, Vector, Vector3};
@@ -678,6 +682,7 @@ impl<N: RealField> Orthographic3<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<Orthographic3<N>> for Standard
 where Standard: Distribution<N>
 {

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 #[cfg(feature = "serde-serialize")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -11,6 +14,7 @@ use std::mem;
 use alga::general::RealField;
 
 use crate::base::dimension::U3;
+#[cfg(feature = "rand")]
 use crate::base::helper;
 use crate::base::storage::Storage;
 use crate::base::{Matrix4, Scalar, Vector, Vector3};
@@ -261,6 +265,7 @@ impl<N: RealField> Perspective3<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<Perspective3<N>> for Standard
 where Standard: Distribution<N>
 {

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -2,8 +2,11 @@
 use quickcheck::{Arbitrary, Gen};
 
 use num::{Bounded, One, Zero};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use alga::general::ClosedDiv;
 use crate::base::allocator::Allocator;
@@ -126,6 +129,7 @@ where DefaultAllocator: Allocator<N, D>
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: Scalar, D: DimName> Distribution<Point<N, D>> for Standard
 where
     DefaultAllocator: Allocator<N, D>,

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -6,8 +6,11 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::{One, Zero};
-use rand::distributions::{Distribution, OpenClosed01, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, OpenClosed01, Standard},
+    Rng,
+};
 
 use alga::general::RealField;
 
@@ -124,6 +127,7 @@ impl<N: RealField> Zero for Quaternion<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<Quaternion<N>> for Standard
 where Standard: Distribution<N>
 {
@@ -685,6 +689,7 @@ impl<N: RealField> One for UnitQuaternion<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<UnitQuaternion<N>> for Standard
 where OpenClosed01: Distribution<N>
 {

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -5,8 +5,11 @@ use quickcheck::{Arbitrary, Gen};
 
 use alga::general::RealField;
 use num::Zero;
-use rand::distributions::{Distribution, OpenClosed01, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, OpenClosed01, Standard},
+    Rng,
+};
 use std::ops::Neg;
 
 use crate::base::dimension::{U1, U2, U3};
@@ -230,6 +233,7 @@ impl<N: RealField> Rotation2<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<Rotation2<N>> for Standard
 where OpenClosed01: Distribution<N>
 {
@@ -817,6 +821,7 @@ impl<N: RealField> Rotation3<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<Rotation3<N>> for Standard
 where OpenClosed01: Distribution<N>
 {

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -4,8 +4,11 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::One;
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use alga::general::RealField;
 use alga::linear::Rotation as AlgaRotation;
@@ -57,6 +60,7 @@ where
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField, D: DimName, R> Distribution<Similarity<N, D, R>> for Standard
 where
     R: AlgaRotation<Point<N, D>>,

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -4,8 +4,11 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::{One, Zero};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use alga::general::ClosedAdd;
 
@@ -47,6 +50,7 @@ where DefaultAllocator: Allocator<N, D>
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: Scalar, D: DimName> Distribution<Translation<N, D>> for Standard
 where
     DefaultAllocator: Allocator<N, D>,

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,8 +3,11 @@ use quickcheck::{Arbitrary, Gen};
 
 use num::One;
 use num_complex::Complex;
-use rand::distributions::{Distribution, OpenClosed01, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    distributions::{Distribution, OpenClosed01, Standard},
+    Rng,
+};
 
 use alga::general::RealField;
 use crate::base::dimension::{U1, U2};
@@ -275,6 +278,7 @@ impl<N: RealField> One for UnitComplex<N> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<N: RealField> Distribution<UnitComplex<N>> for Standard
 where OpenClosed01: Distribution<N>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ extern crate matrixmultiply;
 extern crate num_complex;
 extern crate num_traits as num;
 extern crate num_rational;
+#[cfg(feature = "rand")]
 extern crate rand;
 extern crate typenum;
 


### PR DESCRIPTION
In the light of the rand crate pushing semver-incompatible changes (again) and breaking every (even indirectly) dependent crate, this pull request makes the rand dependency in nalgebra optional. See issues https://github.com/rust-random/rand/issues/818, https://github.com/rust-random/rand/issues/645, https://github.com/rust-random/rand/issues/766, https://github.com/rust-random/rand/issues/754.

Frankly, I'm tired of dealing with this and I would suggest removing the rand crate from the default features outright, but this would be a breaking change, and I'm not sure how to structure `Cargo.toml` so that the tests can still enable this feature.