### PR TITLE
HTTPS All The Things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to `nalgebra`, starting with the version 0.6.0 will be
 documented here.
 
-This project adheres to [Semantic Versioning](http://semver.org/).
+This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.18.0]
 This release adds full complex number support to nalgebra. This includes all common vector/matrix operations as well
@@ -111,7 +111,7 @@ All dependencies have been updated to their latest versions.
 
 ## [0.15.0]
 The most notable change of this release is the support for using part of the library without the rust standard
-library (i.e. it supports `#![no_std]`). See the corresponding [documentation](http://nalgebra.org/wasm_and_embedded_programming/).
+library (i.e. it supports `#![no_std]`). See the corresponding [documentation](https://nalgebra.org/wasm_and_embedded_programming/).
 ### Modified
   * Rename the `core` module to `base` to avoid conflicts with the `core` crate implicitly imported when
     `#![no_std]` is enabled.
@@ -276,7 +276,7 @@ The main change of this release is the update of the dependency serde to 1.0.
    elements.)
 
 ## [0.11.0]
-The [website](http://nalgebra.org) has been fully rewritten and gives a good
+The [website](https://nalgebra.org) has been fully rewritten and gives a good
 overview of all the added/modified features.
 
 This version is a major rewrite of the library. Major changes are:
@@ -298,9 +298,9 @@ This version is a major rewrite of the library. Major changes are:
 
 ### Added
 Lots of features including rectangular matrices, slices, and Serde
-serialization. Refer to the brand new [website](http://nalgebra.org) for more
+serialization. Refer to the brand new [website](https://nalgebra.org) for more
 details. The following free-functions have been added as well:
-  * `::id()` that returns the universal [identity element](http://nalgebra.org/performance_tricks/#the-id-type)
+  * `::id()` that returns the universal [identity element](https://nalgebra.org/performance_tricks/#the-id-type)
     of type `Id`.
   * `::inf_sup()` that returns both the infimum and supremum of a value at the
     same time.
@@ -459,7 +459,7 @@ crate for vectors, rotations and points. To enable them, activate the
 
 ## [0.6.0]
 **Announcement:** a users forum has been created for `nalgebra`, `ncollide`, and `nphysics`. See
-you [there](http://users.nphysics.org)!
+you [there](https://users.nphysics.org)!
 
 ### Added
   * Added a dependency to [generic-array](https://crates.io/crates/generic-array). Feature-gated:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "Linear algebra library with transformations and statically-sized or dynamically-sized matrices."
-documentation = "http://nalgebra.org/rustdoc/nalgebra/index.html"
-homepage = "http://nalgebra.org"
+documentation = "https://nalgebra.org/rustdoc/nalgebra/index.html"
+homepage = "https://nalgebra.org"
 repository = "https://github.com/rustsim/nalgebra"
 readme = "README.md"
 categories = [ "science" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="http://nalgebra.org/img/logo_nalgebra.svg" alt="crates.io">
+  <img src="https://nalgebra.org/img/logo_nalgebra.svg" alt="crates.io">
 </p>
 <p align="center">
     <a href="https://discord.gg/vt9DJSW">
@@ -9,7 +9,7 @@
         <img src="https://travis-ci.org/rustsim/nalgebra.svg?branch=master" alt="Build status">
     </a>
     <a href="https://crates.io/crates/nalgebra">
-         <img src="http://meritbadge.herokuapp.com/nalgebra?style=flat-square" alt="crates.io">
+         <img src="https://meritbadge.herokuapp.com/nalgebra?style=flat-square" alt="crates.io">
     </a>
     <a href="https://opensource.org/licenses/BSD-3-Clause">
         <img src="https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat">
@@ -17,7 +17,7 @@
 </p>
 <p align = "center">
     <strong>
-        <a href="http://nalgebra.org">Users guide</a> | <a href="http://nalgebra.org/rustdoc/nalgebra/index.html">Documentation</a> | <a href="https://discourse.nphysics.org/c/nalgebra">Forum</a>
+        <a href="https://nalgebra.org">Users guide</a> | <a href="https://nalgebra.org/rustdoc/nalgebra/index.html">Documentation</a> | <a href="https://discourse.nphysics.org/c/nalgebra">Forum</a>
     </strong>
 </p>
 

--- a/nalgebra-glm/src/lib.rs
+++ b/nalgebra-glm/src/lib.rs
@@ -7,7 +7,7 @@
    seamless inter-operability between both.
 
    ## Getting started
-   First of all, you should start by taking a look at the official [GLM API documentation](http://glm.g-truc.net/0.9.9/api/index.html)
+   First of all, you should start by taking a look at the official [GLM API documentation](https://glm.g-truc.net/0.9.9/api/index.html)
    since **nalgebra-glm** implements a large subset of it. To use **nalgebra-glm** to your project, you
    should add it as a dependency to your `Crates.toml`:
 
@@ -110,7 +110,7 @@
    and keep in mind it is possible to convert, e.g., an `Isometry3` to a `Mat4` and vice-versa (see the [conversions section](#conversions)).
 */
 
-#![doc(html_favicon_url = "http://nalgebra.org/img/favicon.ico")]
+#![doc(html_favicon_url = "https://nalgebra.org/img/favicon.ico")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate num_traits as num;

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>" ]
 
 description   = "Linear algebra library with transformations and satically-sized or dynamically-sized matrices."
-documentation = "http://nalgebra.org/doc/nalgebra/index.html"
-homepage      = "http://nalgebra.org"
+documentation = "https://nalgebra.org/doc/nalgebra/index.html"
+homepage      = "https://nalgebra.org"
 repository    = "https://github.com/rustsim/nalgebra"
 readme        = "README.md"
 keywords      = [ "linear", "algebra", "matrix", "vector" ]

--- a/nalgebra-lapack/README.md
+++ b/nalgebra-lapack/README.md
@@ -14,7 +14,7 @@ MIT
 
 Like the [lapack crate](https://crates.io/crates/lapack) from which this
 behavior is inherited, nalgebra-lapack uses [cargo
-features](http://doc.crates.io/manifest.html#the-[features]-section) to select
+features](https://doc.crates.io/manifest.html#the-[features]-section) to select
 which lapack provider (or implementation) is used. Command line arguments to
 cargo are the easiest way to do this, and the best provider depends on your
 particular system. In some cases, the providers can be further tuned with

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! Like the [lapack crate](https://crates.io/crates/lapack) from which this
 //! behavior is inherited, nalgebra-lapack uses [cargo
-//! features](http://doc.crates.io/manifest.html#the-[features]-section) to select
+//! features](https://doc.crates.io/manifest.html#the-[features]-section) to select
 //! which lapack provider (or implementation) is used. Command line arguments to
 //! cargo are the easiest way to do this, and the best provider depends on your
 //! particular system. In some cases, the providers can be further tuned with
@@ -69,8 +69,8 @@
 #![deny(unused_results)]
 #![deny(missing_docs)]
 #![doc(
-    html_favicon_url = "http://nalgebra.org/img/favicon.ico",
-    html_root_url = "http://nalgebra.org/rustdoc"
+    html_favicon_url = "https://nalgebra.org/img/favicon.ico",
+    html_root_url = "https://nalgebra.org/rustdoc"
 )]
 
 extern crate alga;

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -311,7 +311,7 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
         }
 
         // All this is inspired from the "unrolled version" discussed in:
-        // http://blog.theincredibleholk.org/blog/2012/12/10/optimizing-dot-product/
+        // https://blog.theincredibleholk.org/blog/2012/12/10/optimizing-dot-product/
         //
         // And this comment from bluss:
         // https://users.rust-lang.org/t/how-to-zip-two-slices-efficiently/2048/12

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -256,7 +256,7 @@ impl<N: RealField> UnitQuaternion<N> {
     #[inline]
     pub fn from_rotation_matrix(rotmat: &Rotation3<N>) -> Self {
         // Robust matrix to quaternion transformation.
-        // See http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion
+        // See https://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion
         let tr = rotmat[(0, 0)] + rotmat[(1, 1)] + rotmat[(2, 2)];
         let res;
 

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -464,7 +464,7 @@ impl<N: RealField> Rotation3<N> {
     /// ```
     pub fn euler_angles(&self) -> (N, N, N) {
         // Implementation informed by "Computing Euler angles from a rotation matrix", by Gregory G. Slabaugh
-        //  http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.371.6578
+        //  https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.371.6578
         if self[(2, 0)].abs() < N::one() {
             let yaw = -self[(2, 0)].asin();
             let roll = (self[(2, 1)] / yaw.cos()).atan2(self[(2, 2)] / yaw.cos());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 * Real-time computer physics.
 
 ## Using **nalgebra**
-You will need the last stable build of the [rust compiler](http://www.rust-lang.org)
+You will need the last stable build of the [rust compiler](https://www.rust-lang.org)
 and the official package manager: [cargo](https://github.com/rust-lang/cargo).
 
 Simply add the following to your `Cargo.toml` file:
@@ -84,8 +84,8 @@ an optimized set of tools for computer graphics and physics. Those features incl
 #![deny(missing_docs)]
 #![warn(incoherent_fundamental_impls)]
 #![doc(
-    html_favicon_url = "http://nalgebra.org/img/favicon.ico",
-    html_root_url = "http://nalgebra.org/rustdoc"
+    html_favicon_url = "https://nalgebra.org/img/favicon.ico",
+    html_root_url = "https://nalgebra.org/rustdoc"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]


### PR DESCRIPTION
When deploying some locally generated documentation to netlify, netlify was "helpfully" spewing out warnings such as this

```
6:05:35 PM: Mixed content detected in: /nalgebra/base/allocator/type.sameshapec.html
6:05:35 PM: --> insecure link urls:
6:05:35 PM:   - http://nalgebra.org/img/favicon.ico
```

And indeed, the [nalegbra site](https://www.nalgebra.org/rustdoc/nalgebra/index.html) itself has a similar warning about insecure content, at least in Firefox.

![image](https://user-images.githubusercontent.com/2316028/59289257-e73b5b80-8c75-11e9-92c7-4d4b4c9d4a71.png)

![image](https://user-images.githubusercontent.com/2316028/59289290-f7ebd180-8c75-11e9-8ecc-4eaafa2b28d1.png)

So this change just basically turns all of the http:// links to https:// including for some links to external sites in some of the comments, I think there was actually only 1 site that didn't have valid HTTPS.