### PR TITLE
Update rand dependency to 0.7 + some tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 
 [features]
 default         = [ "std" ]
-std             = [ "matrixmultiply", "rand/std", "alga/std" ]
+std             = [ "matrixmultiply", "rand/std", "alga/std", "rand_distr" ]
 stdweb          = [ "rand/stdweb" ]
 arbitrary       = [ "quickcheck" ]
 serde-serialize = [ "serde", "serde_derive", "num-complex/serde" ]
@@ -34,7 +34,8 @@ io = [ "pest", "pest_derive" ]
 [dependencies]
 typenum        = "1.10"
 generic-array  = "0.12"
-rand           = { version = "0.6", default-features = false }
+rand           = { version = "0.7", default-features = false }
+rand_distr     = { version = "0.2", optional = true }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
 num-rational   = { version = "0.2", default-features = false }
@@ -54,7 +55,9 @@ pest_derive    = { version = "2.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-rand_xorshift = "0.1"
+rand = { version = "0.7", features = ["small_rng"] }
+# IsaacRng is used by benches; keep for reproducibility?
+rand_isaac = "0.2"
 ### Uncomment this line before running benchmarks.
 ### We can't just let this uncommented because that would breack
 ### compilation for #[no-std] because of the terrible Cargo bug

--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -1,5 +1,4 @@
 use na::{DMatrix, DVector, Matrix2, Matrix3, Matrix4, MatrixN, Vector2, Vector3, Vector4, U10};
-use rand::{IsaacRng, Rng};
 use std::ops::{Add, Div, Mul, Sub};
 
 #[path = "../common/macros.rs"]

--- a/benches/core/vector.rs
+++ b/benches/core/vector.rs
@@ -1,5 +1,6 @@
 use na::{DVector, Vector2, Vector3, Vector4, VectorN};
-use rand::{IsaacRng, Rng};
+use rand::{Rng, SeedableRng};
+use rand_isaac::IsaacRng;
 use std::ops::{Add, Div, Mul, Sub};
 use typenum::U10000;
 
@@ -48,7 +49,6 @@ bench_binop_ref!(vec10000_dot_f64, VectorN<f64, U10000>, VectorN<f64, U10000>, d
 bench_binop_ref!(vec10000_dot_f32, VectorN<f32, U10000>, VectorN<f32, U10000>, dot);
 
 fn vec10000_axpy_f64(bh: &mut criterion::Criterion) {
-    use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
@@ -58,7 +58,6 @@ fn vec10000_axpy_f64(bh: &mut criterion::Criterion) {
 }
 
 fn vec10000_axpy_beta_f64(bh: &mut criterion::Criterion) {
-    use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
@@ -69,7 +68,6 @@ fn vec10000_axpy_beta_f64(bh: &mut criterion::Criterion) {
 }
 
 fn vec10000_axpy_f64_slice(bh: &mut criterion::Criterion) {
-    use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
@@ -84,7 +82,6 @@ fn vec10000_axpy_f64_slice(bh: &mut criterion::Criterion) {
 }
 
 fn vec10000_axpy_f64_static(bh: &mut criterion::Criterion) {
-    use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = VectorN::<f64, U10000>::new_random();
     let b = VectorN::<f64, U10000>::new_random();
@@ -95,7 +92,6 @@ fn vec10000_axpy_f64_static(bh: &mut criterion::Criterion) {
 }
 
 fn vec10000_axpy_f32(bh: &mut criterion::Criterion) {
-    use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
@@ -105,7 +101,6 @@ fn vec10000_axpy_f32(bh: &mut criterion::Criterion) {
 }
 
 fn vec10000_axpy_beta_f32(bh: &mut criterion::Criterion) {
-    use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);

--- a/benches/geometry/quaternion.rs
+++ b/benches/geometry/quaternion.rs
@@ -1,5 +1,4 @@
 use na::{Quaternion, UnitQuaternion, Vector3};
-use rand::{IsaacRng, Rng};
 use std::ops::{Add, Div, Mul, Sub};
 
 #[path = "../common/macros.rs"]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -10,15 +10,14 @@ extern crate typenum;
 extern crate criterion;
 
 use na::DMatrix;
-use rand::{IsaacRng, Rng};
+use rand::{Rng, SeedableRng};
 
 pub mod core;
 pub mod geometry;
 pub mod linalg;
 
 fn reproductible_dmatrix(nrows: usize, ncols: usize) -> DMatrix<f64> {
-    use rand::SeedableRng;
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = rand_isaac::IsaacRng::seed_from_u64(0);
     DMatrix::<f64>::from_fn(nrows, ncols, |_, _| rng.gen())
 }
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -4,6 +4,7 @@ set -ev
 
 if [ -z "$NO_STD" ]; then
     if [ -z "$LAPACK" ]; then
+        cargo build --verbose -p nalgebra --no-default-features --lib;
         cargo build --verbose -p nalgebra;
         cargo build --verbose -p nalgebra --features "arbitrary";
         cargo build --verbose -p nalgebra --features "mint";

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -4,6 +4,7 @@ set -ev
 
 if [ -z "$NO_STD" ]; then
     if [ -z "$LAPACK" ]; then
+        cargo test --verbose --no-default-features --lib;
         cargo test --verbose;
         cargo test --verbose "arbitrary";
         cargo test --verbose --all-features;

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -37,4 +37,4 @@ lapack-src    = { version = "0.2", default-features = false }
 nalgebra   = { version = "0.18", path = "..", features = [ "arbitrary" ] }
 quickcheck = "0.8"
 approx     = "0.3"
-rand       = "0.6"
+rand       = "0.7"

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -7,7 +7,7 @@ use num::{Bounded, One, Zero};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 #[cfg(feature = "std")]
-use rand::{self, distributions::StandardNormal};
+use rand_distr::StandardNormal;
 use std::iter;
 use typenum::{self, Cmp, Greater};
 
@@ -243,7 +243,8 @@ where DefaultAllocator: Allocator<N, R, C>
     #[cfg(feature = "std")]
     pub fn new_random_generic(nrows: R, ncols: C) -> Self
     where Standard: Distribution<N> {
-        Self::from_fn_generic(nrows, ncols, |_, _| rand::random())
+        let mut rng = rand::thread_rng();
+        Self::from_fn_generic(nrows, ncols, |_, _| rng.gen())
     }
 
     /// Creates a matrix filled with random values from the given distribution.
@@ -794,6 +795,7 @@ where
     }
 }
 
+// TODO(specialization): faster impls possible for D≤4 (see rand_distr::{UnitCircle, UnitSphere})
 #[cfg(feature = "std")]
 impl<N: RealField, D: DimName> Distribution<Unit<VectorN<N, D>>> for Standard
 where

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -681,6 +681,7 @@ impl<N: RealField> Orthographic3<N> {
 impl<N: RealField> Distribution<Orthographic3<N>> for Standard
 where Standard: Distribution<N>
 {
+    /// Generate an arbitrary random variate for testing purposes.
     fn sample<R: Rng + ?Sized>(&self, r: &mut R) -> Orthographic3<N> {
         let left = r.gen();
         let right = helper::reject_rand(r, |x: &N| *x > left);

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -264,6 +264,7 @@ impl<N: RealField> Perspective3<N> {
 impl<N: RealField> Distribution<Perspective3<N>> for Standard
 where Standard: Distribution<N>
 {
+    /// Generate an arbitrary random variate for testing purposes.
     fn sample<'a, R: Rng + ?Sized>(&self, r: &'a mut R) -> Perspective3<N> {
         let znear = r.gen();
         let zfar = helper::reject_rand(r, |&x: &N| !(x - znear).is_zero());

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -131,6 +131,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     Standard: Distribution<N>,
 {
+    /// Generates a `Point` where each coordinate is an independent variate from `[0, 1)`.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> Point<N, D> {
         Point::from(rng.gen::<VectorN<N, D>>())

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -724,13 +724,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate rand_xorshift;
     use super::*;
-    use rand::SeedableRng;
+    use rand::{SeedableRng, rngs::SmallRng};
 
     #[test]
     fn random_unit_quats_are_unit() {
-        let mut rng = rand_xorshift::XorShiftRng::from_seed([0xAB; 16]);
+        let mut rng = SmallRng::seed_from_u64(2);
         for _ in 0..1000 {
             let x = rng.gen::<UnitQuaternion<f32>>();
             assert!(relative_eq!(x.into_inner().norm(), 1.0))

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -5,7 +5,7 @@ use quickcheck::{Arbitrary, Gen};
 
 use alga::general::RealField;
 use num::Zero;
-use rand::distributions::{Distribution, OpenClosed01, Standard};
+use rand::distributions::{Distribution, OpenClosed01, Standard, uniform::SampleUniform};
 use rand::Rng;
 use std::ops::Neg;
 
@@ -231,12 +231,12 @@ impl<N: RealField> Rotation2<N> {
 }
 
 impl<N: RealField> Distribution<Rotation2<N>> for Standard
-where OpenClosed01: Distribution<N>
+where N: SampleUniform
 {
     /// Generate a uniformly distributed random rotation.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &'a mut R) -> Rotation2<N> {
-        Rotation2::new(rng.sample(OpenClosed01) * N::two_pi())
+        Rotation2::new(rng.gen_range(N::zero(), N::two_pi()))
     }
 }
 
@@ -818,7 +818,7 @@ impl<N: RealField> Rotation3<N> {
 }
 
 impl<N: RealField> Distribution<Rotation3<N>> for Standard
-where OpenClosed01: Distribution<N>
+where OpenClosed01: Distribution<N>, N: SampleUniform
 {
     /// Generate a uniformly distributed random rotation.
     #[inline]
@@ -828,7 +828,7 @@ where OpenClosed01: Distribution<N>
         // In D. Kirk, editor, Graphics Gems III, pages 117-120. Academic, New York, 1992.
 
         // Compute a random rotation around Z
-        let theta = N::two_pi() * rng.sample(OpenClosed01);
+        let theta = rng.gen_range(N::zero(), N::two_pi());
         let (ts, tc) = theta.sin_cos();
         let a = MatrixN::<N, U3>::new(
             tc,
@@ -843,7 +843,7 @@ where OpenClosed01: Distribution<N>
         );
 
         // Compute a random rotation *of* Z
-        let phi = N::two_pi() * rng.sample(OpenClosed01);
+        let phi = rng.gen_range(N::zero(), N::two_pi());
         let z = rng.sample(OpenClosed01);
         let (ps, pc) = phi.sin_cos();
         let sqrt_z = z.sqrt();

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -63,6 +63,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     Standard: Distribution<N> + Distribution<R>,
 {
+    /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> Similarity<N, D, R> {
         let mut s = rng.gen();

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -52,6 +52,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     Standard: Distribution<N>,
 {
+    /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &'a mut G) -> Translation<N, D> {
         Translation::from(rng.gen::<VectorN<N, D>>())

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 use num::One;
 use num_complex::Complex;
-use rand::distributions::{Distribution, OpenClosed01, Standard};
+use rand::distributions::{Distribution, Standard, uniform::SampleUniform};
 use rand::Rng;
 
 use alga::general::RealField;
@@ -276,12 +276,12 @@ impl<N: RealField> One for UnitComplex<N> {
 }
 
 impl<N: RealField> Distribution<UnitComplex<N>> for Standard
-where OpenClosed01: Distribution<N>
+where N: SampleUniform
 {
     /// Generate a uniformly distributed random `UnitComplex`.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &mut R) -> UnitComplex<N> {
-        UnitComplex::from_angle(rng.sample(OpenClosed01) * N::two_pi())
+        UnitComplex::from_angle(rng.gen_range(N::zero(), N::two_pi()))
     }
 }
 

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 use num::One;
 use num_complex::Complex;
-use rand::distributions::{Distribution, Standard, uniform::SampleUniform};
+use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
 use alga::general::RealField;
@@ -275,8 +275,21 @@ impl<N: RealField> One for UnitComplex<N> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<N: RealField> Distribution<UnitComplex<N>> for Standard
-where N: SampleUniform
+where rand_distr::UnitCircle: Distribution<[N; 2]>
+{
+    /// Generate a uniformly distributed random `UnitComplex`.
+    #[inline]
+    fn sample<'a, R: Rng + ?Sized>(&self, rng: &mut R) -> UnitComplex<N> {
+        let x = rand_distr::UnitCircle.sample(rng);
+        UnitComplex::new_unchecked(Complex::new(x[0], x[1]))
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<N: RealField> Distribution<UnitComplex<N>> for Standard
+where N: rand::distributions::uniform::SampleUniform
 {
     /// Generate a uniformly distributed random `UnitComplex`.
     #[inline]

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -354,6 +354,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn wilkinson_shift_random() {
         for _ in 0..1000 {

--- a/tests/core/helper.rs
+++ b/tests/core/helper.rs
@@ -33,6 +33,7 @@ impl<N: RealField> Distribution<RandComplex<N>> for Standard
 
 // This is a wrapper similar to RandComplex, but for non-complex.
 // This exists only to make generic tests easier to write.
+// Generates variates in the range [0, 1). Do we want this? E.g. we could use standard normal samples instead.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RandScalar<N>(pub N);
 


### PR DESCRIPTION
... I realise this is jumping the gun since `quickcheck` does not yet support Rand 0.7.

Of course this is a breaking change (part of pub API).

Some of the distributions used here are somewhat *arbitrary*, but I guess are fine for testing purposes. However, this does lead to some slightly surprising code when re-used (`nphysics_testbed`):
```
                    color = rand::thread_rng().gen();
                    color *= 1.5;
                    color.x = color.x.min(1.0);
                    color.y = color.y.min(1.0);
                    color.z = color.z.min(1.0);
```