### PR TITLE
Convolution for RealField Matrices

### DIFF
--- a/src/linalg/convolution.rs
+++ b/src/linalg/convolution.rs
@@ -167,25 +167,9 @@ impl<N: RealField> DMatrix<N>  {
         let kernel_min = kernel_size/2;
         let zero = zero::<N>();
         let mut conv = DMatrix::from_element(mat_cols, mat_rows, zero);
-//
-//        for i in 0..(vec + ker - 1) {
-//            let u_i = if i > vec { i - ker } else { 0 };
-//            let u_f = cmp::min(i, vec - 1);
-//
-//            if u_i == u_f {
-//                conv[i] += self[u_i] * kernel[(i - u_i)];
-//            } else {
-//                for u in u_i..(u_f + 1) {
-//                    if i - u < ker {
-//                        conv[i] += self[u] * kernel[(i - u)];
-//                    }
-//                }
-//            }
-//        }
 
         for i in 0..mat_rows {
             for j in 0..mat_cols {
-                let val = *self.index((i,j));
                 for k_i in 0..kernel_size {
                     for k_j in 0..kernel_size {
                         let i_matrix  = (i + k_i - kernel_min) as i32;
@@ -195,7 +179,7 @@ impl<N: RealField> DMatrix<N>  {
                         let is_j_in_range = j_matrix >=0 && j_matrix < mat_cols as i32;
 
                         let convolved_value =
-                            match is_i_in_range && is_i_in_range {
+                            match is_i_in_range && is_j_in_range {
                                 true => {
                                     let pixel_value = *self.index((i_matrix as usize, j_matrix as usize));
                                     let kernel_value = *kernel.index((k_i,k_j));

--- a/src/linalg/convolution.rs
+++ b/src/linalg/convolution.rs
@@ -162,10 +162,9 @@ impl<N: RealField> DMatrix<N>  {
 
     //TODO: rest ?
 
-
 }
 
-impl<N: RealField, R1: Dim +DimName, C1: Dim +DimName> MatrixMN<N, R1, C1> where DefaultAllocator: Allocator<N, R1, C1>  {
+impl<N: RealField, R1: Dim + DimName, C1: Dim + DimName> MatrixMN<N, R1, C1> where DefaultAllocator: Allocator<N, R1, C1>  {
     /// Returns the convolution of the target vector and a kernel.
     ///
     /// # Arguments
@@ -184,8 +183,6 @@ impl<N: RealField, R1: Dim +DimName, C1: Dim +DimName> MatrixMN<N, R1, C1> where
             C2: Dim,
             S2: Storage<N, R2, C2>
     {
-
-
         let mat_rows = self.nrows() as i32;
         let mat_cols = self.ncols() as i32;
 
@@ -193,12 +190,10 @@ impl<N: RealField, R1: Dim +DimName, C1: Dim +DimName> MatrixMN<N, R1, C1> where
 
         convolve(&self, &kernel,&mut conv,mat_rows,mat_cols);
 
-
         conv
     }
 
     //TODO: rest ?
-
 
 }
 
@@ -213,7 +208,6 @@ fn convolve<N, R1, C1, R2, C2, S2>(mat: &MatrixMN<N,R1,C1>, kernel: &Matrix<N, R
         S2: Storage<N, R2, C2>,
         DefaultAllocator: Allocator<N, R1, C1>
     {
-
         let ker_rows =  kernel.data.shape().0.value() as i32;
         let ker_cols = kernel.data.shape().1.value() as i32;
 
@@ -224,7 +218,6 @@ fn convolve<N, R1, C1, R2, C2, S2>(mat: &MatrixMN<N,R1,C1>, kernel: &Matrix<N, R
                 cols received {} and {} respectively.",
                 mat_rows, ker_rows, mat_cols, ker_cols);
         }
-
 
         let kernel_size = ker_rows;
         let kernel_min = kernel_size/2;

--- a/src/linalg/convolution.rs
+++ b/src/linalg/convolution.rs
@@ -163,8 +163,10 @@ impl<N: RealField> DMatrix<N>  {
                 mat_rows, ker_rows, mat_cols, ker_cols);
         }
 
+        let kernel_size = ker_rows;
+        let kernel_min = kernel_size/2;
         let zero = zero::<N>();
-        let mut conv = DMatrix::from_diagonal_element(mat_cols, mat_rows, zero);
+        let mut conv = DMatrix::from_element(mat_cols, mat_rows, zero);
 //
 //        for i in 0..(vec + ker - 1) {
 //            let u_i = if i > vec { i - ker } else { 0 };
@@ -180,6 +182,34 @@ impl<N: RealField> DMatrix<N>  {
 //                }
 //            }
 //        }
+
+        for i in 0..mat_rows {
+            for j in 0..mat_cols {
+                let val = *self.index((i,j));
+                for k_i in 0..kernel_size {
+                    for k_j in 0..kernel_size {
+                        let i_matrix  = (i + k_i - kernel_min) as i32;
+                        let j_matrix = (j + k_j - kernel_min) as i32;
+
+                        let is_i_in_range = i_matrix >=0 && i_matrix < mat_rows as i32;
+                        let is_j_in_range = j_matrix >=0 && j_matrix < mat_cols as i32;
+
+                        let convolved_value =
+                            match is_i_in_range && is_i_in_range {
+                                true => {
+                                    let pixel_value = *self.index((i_matrix as usize, j_matrix as usize));
+                                    let kernel_value = *kernel.index((k_i,k_j));
+                                    kernel_value*pixel_value
+                                }
+                                false => zero
+                            };
+
+                        *conv.index_mut((i,j)) = convolved_value;
+                    }
+                }
+
+            }
+        }
 
         conv
     }

--- a/src/linalg/convolution.rs
+++ b/src/linalg/convolution.rs
@@ -2,9 +2,9 @@ use std::cmp;
 
 use crate::base::allocator::Allocator;
 use crate::base::default_allocator::DefaultAllocator;
-use crate::base::dimension::{Dim, DimAdd, DimDiff, DimSub, DimSum, DimName, DimMul};
+use crate::base::dimension::{Dim, DimAdd, DimDiff, DimSub, DimSum, DimName};
 use crate::storage::Storage;
-use crate::{zero, RealField, Vector, VectorN, U1, Scalar, Matrix, MatrixMN, DMatrix};
+use crate::{zero, RealField, Vector, VectorN, U1, Matrix, MatrixMN, DMatrix};
 use crate::alga::general::Field;
 
 impl<N: RealField, D1: Dim, S1: Storage<N, D1>> Vector<N, D1, S1> {

--- a/src/linalg/convolution.rs
+++ b/src/linalg/convolution.rs
@@ -4,10 +4,11 @@ use crate::base::allocator::Allocator;
 use crate::base::default_allocator::DefaultAllocator;
 use crate::base::dimension::{Dim, DimAdd, DimDiff, DimSub, DimSum};
 use crate::storage::Storage;
-use crate::{zero, RealField, Vector, VectorN, U1};
+use crate::{zero, RealField, Vector, VectorN, U1, Scalar, Matrix, DMatrix};
+use crate::alga::general::Field;
 
 impl<N: RealField, D1: Dim, S1: Storage<N, D1>> Vector<N, D1, S1> {
-    /// Returns the convolution of the target vector and a kernel.
+    /// Returns the convolution of the target vector and a kernel.s
     ///
     /// # Arguments
     ///
@@ -127,4 +128,63 @@ impl<N: RealField, D1: Dim, S1: Storage<N, D1>> Vector<N, D1, S1> {
 
         conv
     }
+}
+
+// TODO: @Investigate -> Only implemented for DMatrix for now as images are usually DMatrix
+impl<N: RealField> DMatrix<N>  {
+    /// Returns the convolution of the target vector and a kernel.
+    ///
+    /// # Arguments
+    ///
+    /// * `kernel` - A Matrix with rows > 0 and cols > 0
+    ///
+    /// # Errors
+    /// Inputs must satisfy `self.shape() >= kernel.shape() > 0`.
+    ///
+    pub fn mat_convolve_full<R1, C1, S1>(
+        &self,
+        kernel: Matrix<N, R1, C1, S1>, //TODO: Would be nice to have an IsOdd trait. As kernels could be of even size atm
+    ) -> DMatrix<N>
+    where
+        R1: Dim,
+        C1: Dim,
+        S1: Storage<N, R1, C1>
+    {
+        let mat_rows = self.nrows();
+        let mat_cols = self.ncols();
+        let ker_rows =  kernel.data.shape().0.value();
+        let ker_cols = kernel.data.shape().1.value();
+
+        if ker_rows == 0 || ker_rows > mat_rows || ker_cols == 0||  ker_cols > mat_cols {
+            panic!(
+                "convolve_full expects `self.nrows() >= kernel.nrows() > 0 and self.ncols() >= kernel.ncols() > 0 `, \
+                rows received {} and {} respectively. \
+                cols received {} and {} respectively.",
+                mat_rows, ker_rows, mat_cols, ker_cols);
+        }
+
+        let zero = zero::<N>();
+        let mut conv = DMatrix::from_diagonal_element(mat_cols, mat_rows, zero);
+//
+//        for i in 0..(vec + ker - 1) {
+//            let u_i = if i > vec { i - ker } else { 0 };
+//            let u_f = cmp::min(i, vec - 1);
+//
+//            if u_i == u_f {
+//                conv[i] += self[u_i] * kernel[(i - u_i)];
+//            } else {
+//                for u in u_i..(u_f + 1) {
+//                    if i - u < ker {
+//                        conv[i] += self[u] * kernel[(i - u)];
+//                    }
+//                }
+//            }
+//        }
+
+        conv
+    }
+
+    //TODO: rest
+
+
 }

--- a/tests/linalg/convolution.rs
+++ b/tests/linalg/convolution.rs
@@ -1,4 +1,4 @@
-use na::{Vector2,Vector3,Vector4,Vector5,DVector, DMatrix};
+use na::{Vector2,Vector3,Vector4,Vector5,DVector, DMatrix, Matrix5, Matrix3};
 use std::panic;
 
 //
@@ -163,29 +163,34 @@ fn convolve_valid_check(){
 // >>> convolve([1,2,3,4],[1,2],"same")
 // array([ 1,  4,  7, 10])
 #[test]
-fn convolve_same_dmat_check(){
+fn convolve_same_mat_check(){
+    let actual_s =  Matrix5::from_vec( vec![3.0,4.0,4.0,4.0,3.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,3.0,4.0,4.0,4.0,3.0]);
+    let expected_s = Matrix5::from_element(1.0).smat_convolve_full(Matrix3::from_vec(vec![0.0,1.0,0.0,1.0,1.0,1.0,0.0,1.0,0.0]));
+
+    assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
+
     let actual_d =  DMatrix::from_vec(5,5, vec![3.0,4.0,4.0,4.0,3.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,3.0,4.0,4.0,4.0,3.0]);
-    let expected_d = DMatrix::from_element(5,5,1.0).mat_convolve_full(DMatrix::from_vec(3,3,vec![0.0,1.0,0.0,1.0,1.0,1.0,0.0,1.0,0.0]));
+    let expected_d = DMatrix::from_element(5,5,1.0).dmat_convolve_full(DMatrix::from_vec(3,3,vec![0.0,1.0,0.0,1.0,1.0,1.0,0.0,1.0,0.0]));
 
     assert!(relative_eq!(actual_d, expected_d, epsilon = 1.0e-7));
 
-//    // Panic Tests
-//    // These really only apply to dynamic sized vectors
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::from_vec(vec![1.0, 2.0]).convolve_same(DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
-//        }).is_err()
-//    );
-//
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::<f32>::from_vec(vec![]).convolve_same(DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
-//        }).is_err()
-//    );
-//
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0]).convolve_same(DVector::<f32>::from_vec(vec![]));
-//        }).is_err()
-//    );
+    // Panic Tests
+    // These really only apply to dynamic sized vectors
+    assert!(
+        panic::catch_unwind(|| {
+            DMatrix::from_element(2,2,1.0).dmat_convolve_full(DMatrix::from_vec(3,3,vec![0.0,1.0,0.0,1.0,1.0,1.0,0.0,1.0,0.0]));
+        }).is_err()
+    );
+
+    assert!(
+        panic::catch_unwind(|| {
+            DMatrix::from_element(0,0,1.0).dmat_convolve_full(DMatrix::from_vec(3,3,vec![0.0,1.0,0.0,1.0,1.0,1.0,0.0,1.0,0.0]));
+        }).is_err()
+    );
+
+    assert!(
+        panic::catch_unwind(|| {
+            DMatrix::from_element(5,5,1.0).dmat_convolve_full(DMatrix::from_vec(0,0,vec![]));
+        }).is_err()
+    );
 }

--- a/tests/linalg/convolution.rs
+++ b/tests/linalg/convolution.rs
@@ -43,6 +43,43 @@ fn convolve_same_check(){
     );
 }
 
+//// >>> convolve([1,2,3,4],[1,2],"same")
+//// array([ 1,  4,  7, 10])
+//#[test]
+//fn convolve_same_integers_check(){
+//    // Static Tests
+//    let actual_s =  Vector4::new(1, 4, 7, 10);
+//    let expected_s = Vector4::new(1, 2, 3, 4).convolve_same(Vector2::new(1, 2));
+//
+//    assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
+//
+//    // Dynamic Tests
+//    let actual_d =  DVector::from_vec(vec![1, 4, 7, 10]);
+//    let expected_d = DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::from_vec(vec![1, 2]));
+//
+//    assert!(relative_eq!(actual_d, expected_d, epsilon = 1.0e-7));
+//
+//    // Panic Tests
+//    // These really only apply to dynamic sized vectors
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::from_vec(vec![1, 2]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
+//        }).is_err()
+//    );
+//
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::<usize>::from_vec(vec![]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
+//        }).is_err()
+//    );
+//
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::<usize>::from_vec(vec![]));
+//        }).is_err()
+//    );
+//}
+
 // >>> convolve([1,2,3,4],[1,2],"full")
 // array([ 1, 4,  7, 10, 8])
 #[test]

--- a/tests/linalg/convolution.rs
+++ b/tests/linalg/convolution.rs
@@ -118,50 +118,22 @@ fn convolve_valid_check(){
 
 }
 
-//// >>> convolve([1,2,3,4],[1,2],"same")
-//// array([ 1,  4,  7, 10])
-//#[test]
-//fn convolve_same_integers_check(){
-//    // Static Tests
-//    let actual_s =  Vector4::new(1, 4, 7, 10);
-//    let expected_s = Vector4::new(1, 2, 3, 4).convolve_same(Vector2::new(1, 2));
 //
-//    assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
+// mat([ 1, 1, 1, 1, 1,
+//       1, 1, 1, 1, 1,
+//       1, 1, 1, 1, 1,
+//       1, 1, 1, 1, 1,
+//       1, 1, 1, 1, 1])
 //
-//    // Dynamic Tests
-//    let actual_d =  DVector::from_vec(vec![1, 4, 7, 10]);
-//    let expected_d = DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::from_vec(vec![1, 2]));
+// kernel([ 0, 1, 0,
+//          1, 1, 1,
+//          0, 1, 0,])
 //
-//    assert!(relative_eq!(actual_d, expected_d, epsilon = 1.0e-7));
-//
-//    // Panic Tests
-//    // These really only apply to dynamic sized vectors
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::from_vec(vec![1, 2]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
-//        }).is_err()
-//    );
-//
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::<usize>::from_vec(vec![]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
-//        }).is_err()
-//    );
-//
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::<usize>::from_vec(vec![]));
-//        }).is_err()
-//    );
-//}
-
-//
-// Should mimic calculations in Python's scipy library
-// >>>from scipy.signal import convolve
-//
-
-// >>> convolve([1,2,3,4],[1,2],"same")
-// array([ 1,  4,  7, 10])
+// res([ 3, 4, 4, 4, 3,
+//       4, 5, 5, 5, 4,
+//       4, 5, 5, 5, 4,
+//       4, 5, 5, 5, 4,
+//       3, 4, 4, 4, 3])
 #[test]
 fn convolve_same_mat_check(){
     let actual_s =  Matrix5::from_vec( vec![3.0,4.0,4.0,4.0,3.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,3.0,4.0,4.0,4.0,3.0]);

--- a/tests/linalg/convolution.rs
+++ b/tests/linalg/convolution.rs
@@ -1,4 +1,4 @@
-use na::{Vector2,Vector3,Vector4,Vector5,DVector};
+use na::{Vector2,Vector3,Vector4,Vector5,DVector, DMatrix};
 use std::panic;
 
 //
@@ -42,43 +42,6 @@ fn convolve_same_check(){
         }).is_err()
     );
 }
-
-//// >>> convolve([1,2,3,4],[1,2],"same")
-//// array([ 1,  4,  7, 10])
-//#[test]
-//fn convolve_same_integers_check(){
-//    // Static Tests
-//    let actual_s =  Vector4::new(1, 4, 7, 10);
-//    let expected_s = Vector4::new(1, 2, 3, 4).convolve_same(Vector2::new(1, 2));
-//
-//    assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
-//
-//    // Dynamic Tests
-//    let actual_d =  DVector::from_vec(vec![1, 4, 7, 10]);
-//    let expected_d = DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::from_vec(vec![1, 2]));
-//
-//    assert!(relative_eq!(actual_d, expected_d, epsilon = 1.0e-7));
-//
-//    // Panic Tests
-//    // These really only apply to dynamic sized vectors
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::from_vec(vec![1, 2]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
-//        }).is_err()
-//    );
-//
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::<usize>::from_vec(vec![]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
-//        }).is_err()
-//    );
-//
-//    assert!(
-//        panic::catch_unwind(|| {
-//            DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::<usize>::from_vec(vec![]));
-//        }).is_err()
-//    );
-//}
 
 // >>> convolve([1,2,3,4],[1,2],"full")
 // array([ 1, 4,  7, 10, 8])
@@ -153,4 +116,76 @@ fn convolve_valid_check(){
         }).is_err()
     );
 
+}
+
+//// >>> convolve([1,2,3,4],[1,2],"same")
+//// array([ 1,  4,  7, 10])
+//#[test]
+//fn convolve_same_integers_check(){
+//    // Static Tests
+//    let actual_s =  Vector4::new(1, 4, 7, 10);
+//    let expected_s = Vector4::new(1, 2, 3, 4).convolve_same(Vector2::new(1, 2));
+//
+//    assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
+//
+//    // Dynamic Tests
+//    let actual_d =  DVector::from_vec(vec![1, 4, 7, 10]);
+//    let expected_d = DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::from_vec(vec![1, 2]));
+//
+//    assert!(relative_eq!(actual_d, expected_d, epsilon = 1.0e-7));
+//
+//    // Panic Tests
+//    // These really only apply to dynamic sized vectors
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::from_vec(vec![1, 2]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
+//        }).is_err()
+//    );
+//
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::<usize>::from_vec(vec![]).convolve_same(DVector::from_vec(vec![1, 2, 3, 4]));
+//        }).is_err()
+//    );
+//
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::from_vec(vec![1, 2, 3, 4]).convolve_same(DVector::<usize>::from_vec(vec![]));
+//        }).is_err()
+//    );
+//}
+
+//
+// Should mimic calculations in Python's scipy library
+// >>>from scipy.signal import convolve
+//
+
+// >>> convolve([1,2,3,4],[1,2],"same")
+// array([ 1,  4,  7, 10])
+#[test]
+fn convolve_same_dmat_check(){
+    let actual_d =  DMatrix::from_vec(5,5, vec![3.0,4.0,4.0,4.0,3.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,4.0,5.0,5.0,5.0,4.0,3.0,4.0,4.0,4.0,3.0]);
+    let expected_d = DMatrix::from_element(5,5,1.0).mat_convolve_full(DMatrix::from_vec(3,3,vec![0.0,1.0,0.0,1.0,1.0,1.0,0.0,1.0,0.0]));
+
+    assert!(relative_eq!(actual_d, expected_d, epsilon = 1.0e-7));
+
+//    // Panic Tests
+//    // These really only apply to dynamic sized vectors
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::from_vec(vec![1.0, 2.0]).convolve_same(DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
+//        }).is_err()
+//    );
+//
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::<f32>::from_vec(vec![]).convolve_same(DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
+//        }).is_err()
+//    );
+//
+//    assert!(
+//        panic::catch_unwind(|| {
+//            DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0]).convolve_same(DVector::<f32>::from_vec(vec![]));
+//        }).is_err()
+//    );
 }


### PR DESCRIPTION
1/2 of https://discourse.nphysics.org/t/does-filtering-convolution-fit-into-this-library/359/10

I not sure if this is the most efficient implementation. But it works.
There are some comments you might want to read.

1) An IsOdd trait would be somewhat helpful as (I believe) matrix filter kernels should always be odd.

2) Im not sure what the difference between convolve_full, _same and _valid is with respect to matrices. I only implemented a "convolve_full"