### PR TITLE
Basic matrixcompare functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ rand_isaac = "0.2"
 #criterion = "0.2.10"
 
 # For matrix comparison macro
-matrixcompare = "0.1"
+matrixcompare = "0.1.3"
 
 [workspace]
 members = [ "nalgebra-lapack", "nalgebra-glm" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sparse = [ ]
 debug = [ "approx/num-complex", "rand/std" ]
 alloc = [ ]
 io = [ "pest", "pest_derive" ]
+compare = [ "matrixcompare-core" ]
 
 [dependencies]
 typenum        = "1.11"
@@ -50,6 +51,7 @@ mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "0.9", optional = true }
 pest           = { version = "2.0", optional = true }
 pest_derive    = { version = "2.0", optional = true }
+matrixcompare-core = { version = "0.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -60,6 +62,9 @@ rand_isaac = "0.2"
 ### compilation for #[no-std] because of the terrible Cargo bug
 ### https://github.com/rust-lang/cargo/issues/4866
 #criterion = "0.2.10"
+
+# For matrix comparison macro
+matrixcompare = "0.1"
 
 [workspace]
 members = [ "nalgebra-lapack", "nalgebra-glm" ]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	cargo test --features "debug arbitrary serde-serialize abomonation-serialize"
+	cargo test --features "debug arbitrary serde-serialize abomonation-serialize compare"
 	# cargo check --features "debug arbitrary serde-serialize"
 
 doc:
@@ -9,4 +9,4 @@ bench:
 	cargo bench
 
 test:
-	cargo test --features "debug arbitrary serde-serialize abomonation-serialize"
+	cargo test --features "debug arbitrary serde-serialize abomonation-serialize compare"

--- a/examples/matrixcompare.rs
+++ b/examples/matrixcompare.rs
@@ -1,0 +1,79 @@
+extern crate nalgebra as na;
+
+#[macro_use]
+extern crate quickcheck;
+
+use na::{U3, U4, MatrixMN};
+use matrixcompare::compare_matrices;
+use matrixcompare::comparators::{ExactElementwiseComparator, AbsoluteElementwiseComparator};
+
+fn compare_integers_fail() {
+    println!("Comparing two integer matrices.");
+
+    let a = MatrixMN::<_, U3, U4>::from_row_slice(&[
+        0, 1,  2,  3,
+        4, 5,  6,  7,
+        8, 9, -2, 11
+    ]);
+
+    let b = MatrixMN::<_, U3, U4>::from_row_slice(&[
+        0, 1,  2,  3,
+        4, 5,  6,  7,
+        8, 9, 10, 11
+    ]);
+
+    if let Some(msg) = compare_matrices(a, b, &ExactElementwiseComparator).panic_message() {
+        println!("{}", msg);
+    }
+}
+
+fn compare_different_size() {
+    println!("Comparing matrices of different size.");
+    let a = MatrixMN::<_, U3, U3>::from_row_slice(&[
+        0, 1,  2,
+        4, 5,  6,
+        8, 9, 10,
+    ]);
+
+    let b = MatrixMN::<_, U3, U4>::from_row_slice(&[
+        0, 1,  2,  3,
+        4, 5,  6,  7,
+        8, 9, 10, 11
+    ]);
+
+    if let Some(msg) = compare_matrices(a, b, &ExactElementwiseComparator).panic_message() {
+        println!("{}", msg);
+    }
+}
+
+fn compare_f64_abs_tol_fail() {
+    println!("Comparing two f64 matrices.");
+
+    let a = MatrixMN::<f64, U3, U3>::from_row_slice(&[
+        0.0, 1.0,  2.0 + 1e-10,
+        4.0, 5.0,  6.0,
+        8.0, 9.0, 10.0,
+    ]);
+
+    let b = MatrixMN::<_, U3, U3>::from_row_slice(&[
+        0.0, 1.0,  2.0,
+        4.0, 5.0,  6.0,
+        8.0, 9.0, 10.0
+    ]);
+
+    let cmp = AbsoluteElementwiseComparator { tol: 1e-12 };
+    if let Some(msg) = compare_matrices(a, b, &cmp).panic_message() {
+        println!("{}", msg);
+    }
+}
+
+fn main() {
+    // This example mostly serves the purpose of demonstrating the kind of error messages
+    // that are given upon comparison failure.
+    // The more typical use case is using `assert_matrix_eq!` in tests.
+    compare_integers_fail();
+    println!("======================================================");
+    compare_f64_abs_tol_fail();
+    println!("======================================================");
+    compare_different_size();
+}

--- a/examples/matrixcompare.rs
+++ b/examples/matrixcompare.rs
@@ -1,60 +1,63 @@
 extern crate nalgebra as na;
 
-#[macro_use]
-extern crate quickcheck;
-
-use na::{U3, U4, MatrixMN};
+use matrixcompare::comparators::{AbsoluteElementwiseComparator, ExactElementwiseComparator};
 use matrixcompare::compare_matrices;
-use matrixcompare::comparators::{ExactElementwiseComparator, AbsoluteElementwiseComparator};
+use na::{MatrixMN, U3, U4};
 
 fn compare_integers_fail() {
     println!("Comparing two integer matrices.");
 
+    #[rustfmt::skip]
     let a = MatrixMN::<_, U3, U4>::from_row_slice(&[
         0, 1,  2,  3,
         4, 5,  6,  7,
         8, 9, -2, 11
     ]);
 
+    #[rustfmt::skip]
     let b = MatrixMN::<_, U3, U4>::from_row_slice(&[
         0, 1,  2,  3,
         4, 5,  6,  7,
         8, 9, 10, 11
     ]);
 
-    if let Some(msg) = compare_matrices(a, b, &ExactElementwiseComparator).panic_message() {
-        println!("{}", msg);
+    if let Err(err) = compare_matrices(a, b, &ExactElementwiseComparator) {
+        println!("{}", err);
     }
 }
 
 fn compare_different_size() {
     println!("Comparing matrices of different size.");
+    #[rustfmt::skip]
     let a = MatrixMN::<_, U3, U3>::from_row_slice(&[
         0, 1,  2,
         4, 5,  6,
         8, 9, 10,
     ]);
 
+    #[rustfmt::skip]
     let b = MatrixMN::<_, U3, U4>::from_row_slice(&[
         0, 1,  2,  3,
         4, 5,  6,  7,
         8, 9, 10, 11
     ]);
 
-    if let Some(msg) = compare_matrices(a, b, &ExactElementwiseComparator).panic_message() {
-        println!("{}", msg);
+    if let Err(err) = compare_matrices(a, b, &ExactElementwiseComparator) {
+        println!("{}", err);
     }
 }
 
 fn compare_f64_abs_tol_fail() {
     println!("Comparing two f64 matrices.");
 
+    #[rustfmt::skip]
     let a = MatrixMN::<f64, U3, U3>::from_row_slice(&[
         0.0, 1.0,  2.0 + 1e-10,
         4.0, 5.0,  6.0,
         8.0, 9.0, 10.0,
     ]);
 
+    #[rustfmt::skip]
     let b = MatrixMN::<_, U3, U3>::from_row_slice(&[
         0.0, 1.0,  2.0,
         4.0, 5.0,  6.0,
@@ -62,8 +65,8 @@ fn compare_f64_abs_tol_fail() {
     ]);
 
     let cmp = AbsoluteElementwiseComparator { tol: 1e-12 };
-    if let Some(msg) = compare_matrices(a, b, &cmp).panic_message() {
-        println!("{}", msg);
+    if let Err(err) = compare_matrices(a, b, &cmp) {
+        println!("{}", err);
     }
 }
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -160,8 +160,9 @@ impl<N: Scalar, R: Dim, C: Dim, S: Abomonation> Abomonation for Matrix<N, R, C, 
 }
 
 #[cfg(feature = "compare")]
-impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>>
-    matrixcompare_core::Matrix<N> for Matrix<N, R, C, S> {
+impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> matrixcompare_core::Matrix<N>
+    for Matrix<N, R, C, S>
+{
     fn rows(&self) -> usize {
         self.nrows()
     }
@@ -176,8 +177,9 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>>
 }
 
 #[cfg(feature = "compare")]
-impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>>
-    matrixcompare_core::DenseAccess<N> for Matrix<N, R, C, S> {
+impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> matrixcompare_core::DenseAccess<N>
+    for Matrix<N, R, C, S>
+{
     fn fetch_single(&self, row: usize, col: usize) -> N {
         self.index((row, col)).clone()
     }

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -159,6 +159,30 @@ impl<N: Scalar, R: Dim, C: Dim, S: Abomonation> Abomonation for Matrix<N, R, C, 
     }
 }
 
+#[cfg(feature = "compare")]
+impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>>
+    matrixcompare_core::Matrix<N> for Matrix<N, R, C, S> {
+    fn rows(&self) -> usize {
+        self.nrows()
+    }
+
+    fn cols(&self) -> usize {
+        self.ncols()
+    }
+
+    fn access(&self) -> matrixcompare_core::Access<N> {
+        matrixcompare_core::Access::Dense(self)
+    }
+}
+
+#[cfg(feature = "compare")]
+impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>>
+    matrixcompare_core::DenseAccess<N> for Matrix<N, R, C, S> {
+    fn fetch_single(&self, row: usize, col: usize) -> N {
+        self.index((row, col)).clone()
+    }
+}
+
 impl<N: Scalar, R: Dim, C: Dim, S> Matrix<N, R, C, S> {
     /// Creates a new matrix with the given data without statically checking that the matrix
     /// dimension matches the storage dimension.

--- a/tests/core/matrixcompare.rs
+++ b/tests/core/matrixcompare.rs
@@ -4,7 +4,7 @@
 //! The tests here only check that the necessary trait implementations are correctly implemented,
 //! in addition to some sanity checks with example input.
 
-use nalgebra::{U4, U5, MatrixMN, DMatrix};
+use nalgebra::{DMatrix, MatrixMN, U4, U5};
 
 use matrixcompare::{assert_matrix_eq, DenseAccess};
 
@@ -31,6 +31,7 @@ quickcheck! {
 
 #[test]
 fn assert_matrix_eq_dense_positive_comparison() {
+    #[rustfmt::skip]
     let a = MatrixMN::<_, U4, U5>::from_row_slice(&[
         1210, 1320, 1430, 1540, 1650,
         2310, 2420, 2530, 2640, 2750,
@@ -38,6 +39,7 @@ fn assert_matrix_eq_dense_positive_comparison() {
         4510, 4620, 4730, 4840, 4950,
     ]);
 
+    #[rustfmt::skip]
     let b = MatrixMN::<_, U4, U5>::from_row_slice(&[
         1210, 1320, 1430, 1540, 1650,
         2310, 2420, 2530, 2640, 2750,
@@ -63,6 +65,7 @@ fn assert_matrix_eq_dense_positive_comparison() {
 #[test]
 #[should_panic]
 fn assert_matrix_eq_dense_negative_comparison() {
+    #[rustfmt::skip]
     let a = MatrixMN::<_, U4, U5>::from_row_slice(&[
         1210, 1320, 1430, 1540, 1650,
         2310, 2420, 2530, 2640, 2750,
@@ -70,6 +73,7 @@ fn assert_matrix_eq_dense_negative_comparison() {
         4510, 4620, -4730, 4840, 4950,
     ]);
 
+    #[rustfmt::skip]
     let b = MatrixMN::<_, U4, U5>::from_row_slice(&[
         1210, 1320, 1430, 1540, 1650,
         2310, 2420, 2530, 2640, 2750,

--- a/tests/core/matrixcompare.rs
+++ b/tests/core/matrixcompare.rs
@@ -1,0 +1,81 @@
+//! Tests for `matrixcompare` integration.
+//!
+//! The `matrixcompare` crate itself is responsible for testing the actual comparison.
+//! The tests here only check that the necessary trait implementations are correctly implemented,
+//! in addition to some sanity checks with example input.
+
+use nalgebra::{U4, U5, MatrixMN, DMatrix};
+
+use matrixcompare::{assert_matrix_eq, DenseAccess};
+
+#[cfg(feature = "arbitrary")]
+quickcheck! {
+    fn fetch_single_is_equivalent_to_index_f64(matrix: DMatrix<f64>) -> bool {
+        for i in 0 .. matrix.nrows() {
+            for j in 0 .. matrix.ncols() {
+                if matrix.fetch_single(i, j) != *matrix.index((i, j)) {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn matrixcompare_shape_agrees_with_matrix(matrix: DMatrix<f64>) -> bool {
+        matrix.nrows() == <DMatrix<f64> as matrixcompare::Matrix<f64>>::rows(&matrix)
+        &&
+        matrix.ncols() == <DMatrix<f64> as matrixcompare::Matrix<f64>>::cols(&matrix)
+    }
+}
+
+#[test]
+fn assert_matrix_eq_dense_positive_comparison() {
+    let a = MatrixMN::<_, U4, U5>::from_row_slice(&[
+        1210, 1320, 1430, 1540, 1650,
+        2310, 2420, 2530, 2640, 2750,
+        3410, 3520, 3630, 3740, 3850,
+        4510, 4620, 4730, 4840, 4950,
+    ]);
+
+    let b = MatrixMN::<_, U4, U5>::from_row_slice(&[
+        1210, 1320, 1430, 1540, 1650,
+        2310, 2420, 2530, 2640, 2750,
+        3410, 3520, 3630, 3740, 3850,
+        4510, 4620, 4730, 4840, 4950,
+    ]);
+
+    // Test matrices of static size
+    assert_matrix_eq!(a, b);
+    assert_matrix_eq!(&a, b);
+    assert_matrix_eq!(a, &b);
+    assert_matrix_eq!(&a, &b);
+
+    // Test matrices of dynamic size
+    let a_dyn = a.index((0..4, 0..5));
+    let b_dyn = b.index((0..4, 0..5));
+    assert_matrix_eq!(a_dyn, b_dyn);
+    assert_matrix_eq!(a_dyn, &b_dyn);
+    assert_matrix_eq!(&a_dyn, b_dyn);
+    assert_matrix_eq!(&a_dyn, &b_dyn);
+}
+
+#[test]
+#[should_panic]
+fn assert_matrix_eq_dense_negative_comparison() {
+    let a = MatrixMN::<_, U4, U5>::from_row_slice(&[
+        1210, 1320, 1430, 1540, 1650,
+        2310, 2420, 2530, 2640, 2750,
+        3410, 3520, 3630, 3740, 3850,
+        4510, 4620, -4730, 4840, 4950,
+    ]);
+
+    let b = MatrixMN::<_, U4, U5>::from_row_slice(&[
+        1210, 1320, 1430, 1540, 1650,
+        2310, 2420, 2530, 2640, 2750,
+        3410, 3520, 3630, 3740, 3850,
+        4510, 4620, 4730, 4840, 4950,
+    ]);
+
+    assert_matrix_eq!(a, b);
+}

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -10,5 +10,8 @@ mod matrix_slice;
 mod mint;
 mod serde;
 
+#[cfg(feature = "compare")]
+mod matrixcompare;
+
 #[cfg(feature = "arbitrary")]
 pub mod helper;


### PR DESCRIPTION
~~**Note: this is not ready for merging. I'm posting it here for some initial feedback.**~~
*Update: This is in principle finalized and ready for merging (barring minor issues, see below)*.

This PR provides `matrixcompare` functionality for `nalgebra`. `matrixcompare` is a crate which aims to provide generic functionality for debug comparisons of matrices. A consumer crate like `nalgebra` only needs to define how many rows/columns a matrix has and how to fetch coefficients. Macros like `assert_matrix_eq!` then makes it easy to compare matrices with different kinds of comparators (absolute tolerance, relative tolerance etc.), which significantly simplifies debugging when writing unit tests involving linear algebra code.

`matrixcompare` is the result of extracting, rewriting and generalizing similar functionality found in the `rulinalg` crate (and also originally contributed by me).

Note that `matrixcompare` is currently not published, and is also not complete. Obviously, this will have to be remedied before this PR can be merged. I open it now so that I can perhaps have some initial feedback (including CI runs).

Below is an excerpt from one of the new tests.

```rust
let a = MatrixMN::<_, U4, U5>::from_row_slice(&[
        1210, 1320, 1430, 1540, 1650,
        2310, 2420, 2530, 2640, 2750,
        3410, 3520, 3630, 3740, 3850,
        4510, 4620, -4730, 4840, 4950,
]);

let b = MatrixMN::<_, U4, U5>::from_row_slice(&[
        1210, 1320, 1430, 1540, 1650,
        2310, 2420, 2530, 2640, 2750,
        3410, 3520, 3630, 3740, 3850,
        4510, 4620, 4730, 4840, 4950,
]);

assert_matrix_eq!(a, b);
```

And this is the output (format subject to change) at the time of writing:

```
Matrices X and Y have 1 mismatched element pairs.
The mismatched elements are listed below, in the format
(row, col): x = X[[row, col]], y = Y[[row, col]].

 (3, 2): x = -4730, y = 4730.

Comparison criterion: exact equality x == y.
Please see the documentation for ways to compare matrices approximately.
```


