### PR TITLE
Matrix::transform_point: correctly take the normalization term into account.

### DIFF
--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -358,10 +358,10 @@ where DefaultAllocator: Allocator<N, D, D>
             + unsafe { *self.get_unchecked((D::dim() - 1, D::dim() - 1)) };
 
         if !n.is_zero() {
-            return transform * (pt / n) + translation;
+            (transform * pt + translation) / n
+        } else {
+            transform * pt + translation
         }
-
-        transform * pt + translation
     }
 }
 

--- a/tests/geometry/projection.rs
+++ b/tests/geometry/projection.rs
@@ -1,4 +1,4 @@
-use na::{Orthographic3, Perspective3};
+use na::{Orthographic3, Perspective3, Point3};
 
 #[test]
 fn perspective_inverse() {
@@ -18,6 +18,19 @@ fn orthographic_inverse() {
     let id = inv * proj.into_inner();
 
     assert!(id.is_identity(1.0e-7));
+}
+
+#[test]
+fn perspective_matrix_point_transformation() {
+    // https://github.com/rustsim/nalgebra/issues/640
+    let proj = Perspective3::new(4.0 / 3.0, 90.0, 0.1, 100.0);
+    let perspective_inv = proj.as_matrix().try_inverse().unwrap();
+    let some_point = Point3::new(1.0, 2.0, 0.0);
+
+    assert_eq!(
+        perspective_inv.transform_point(&some_point),
+        Point3::from_homogeneous(perspective_inv * some_point.coords.push(1.0)).unwrap()
+    );
 }
 
 #[cfg(feature = "arbitrary")]


### PR DESCRIPTION
Fix #640