### PR TITLE
[v0.16] Fix NLL compatibility

### DIFF
--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -288,7 +288,8 @@ impl<N: Scalar + Ring, D: DimName, S: StorageMut<N, D, D>> SquareMatrix<N, D, S>
     {
         for i in 0..D::dim() {
             for j in 0..D::dim() - 1 {
-                self[(j, i)] += shift[j] * self[(D::dim() - 1, i)];
+                let add = shift[j] * self[(D::dim() - 1, i)];
+                self[(j, i)] += add;
             }
         }
     }


### PR DESCRIPTION
Uncovered by a crater run in https://github.com/rust-lang/rust/pull/63565, the most recent v0.16.x version breaks when NLL is fully enabled. This PR is targeted to be based atop tag v0.16.13 (it's probably easiest to merge it manually, unless you want to create a branch for this PR to target).

