### PR TITLE
Rand 0.6 -> 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 
 [features]
 default         = [ "std" ]
-std             = [ "matrixmultiply", "rand/std", "alga/std" ]
+std             = [ "matrixmultiply", "rand/std", "rand_distr", "alga/std" ]
 stdweb          = [ "rand/stdweb" ]
 arbitrary       = [ "quickcheck" ]
 serde-serialize = [ "serde", "serde_derive", "num-complex/serde" ]
@@ -34,18 +34,19 @@ io = [ "pest", "pest_derive" ]
 [dependencies]
 typenum        = "1.10"
 generic-array  = "0.12"
-rand           = { version = "0.6", default-features = false }
+rand           = { version = "0.7", default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
 num-rational   = { version = "0.2", default-features = false }
 approx         = { version = "0.3", default-features = false }
 alga           = { version = "0.9", default-features = false }
+rand_distr     = { version = "0.2", optional = true }
 matrixmultiply = { version = "0.2", optional = true }
 serde          = { version = "1.0", optional = true }
 serde_derive   = { version = "1.0", optional = true }
 abomonation    = { version = "0.7", optional = true }
 mint           = { version = "0.5", optional = true }
-quickcheck     = { version = "0.8", optional = true }
+quickcheck     = { version = "0.9", optional = true }
 pest           = { version = "2.0", optional = true }
 pest_derive    = { version = "2.0", optional = true }
 
@@ -54,7 +55,7 @@ pest_derive    = { version = "2.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-rand_xorshift = "0.1"
+rand_xorshift = "0.2"
 ### Uncomment this line before running benchmarks.
 ### We can't just let this uncommented because that would break
 ### compilation for #[no-std] because of the terrible Cargo bug

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -35,6 +35,6 @@ lapack-src    = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 nalgebra   = { version = "0.18", path = "..", features = [ "arbitrary" ] }
-quickcheck = "0.8"
+quickcheck = "0.9"
 approx     = "0.3"
-rand       = "0.6"
+rand       = "0.7"

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -7,7 +7,9 @@ use num::{Bounded, One, Zero};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 #[cfg(feature = "std")]
-use rand::{self, distributions::StandardNormal};
+use rand;
+#[cfg(feature = "std")]
+use rand_distr::StandardNormal;
 use std::iter;
 use typenum::{self, Cmp, Greater};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ extern crate num_complex;
 extern crate num_traits as num;
 extern crate num_rational;
 extern crate rand;
+#[cfg(feature = "std")]
+extern crate rand_distr;
 extern crate typenum;
 
 extern crate alga;


### PR DESCRIPTION
With the new version of rand it is possible to use `Distribution<f32>` with `Matrix::from_distribution`, which is pretty handy.

* Bumped rand version to 0.7
* Added dependency to rand_distr
* Bumped quickcheck version to 0.9 (because of rand)
* Bumped rand_xorshift version to 0.2