### PR TITLE
Don't call 'offset' on a dangling pointer

### DIFF
--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -72,7 +72,16 @@ pub unsafe trait Storage<N: Scalar, R: Dim, C: Dim = U1>: Debug + Sized {
     /// Gets the address of the i-th matrix component without performing bound-checking.
     #[inline]
     unsafe fn get_address_unchecked_linear(&self, i: usize) -> *const N {
-        self.ptr().offset(i as isize)
+        let shape = self.shape();
+        if shape.0.value() * shape.1.value() == 0 {
+            // If we have a zero-size matrix, our pointer must
+            // be dangling. Instead of calling 'offset', we
+            // just re-use our pointer, since actually using
+            // it would be undefined behavior
+            self.ptr()
+        } else {
+            self.ptr().offset(i as isize)
+        }
     }
 
     /// Gets the address of the i-th matrix component without performing bound-checking.
@@ -124,7 +133,16 @@ pub unsafe trait StorageMut<N: Scalar, R: Dim, C: Dim = U1>: Storage<N, R, C> {
     /// Gets the mutable address of the i-th matrix component without performing bound-checking.
     #[inline]
     unsafe fn get_address_unchecked_linear_mut(&mut self, i: usize) -> *mut N {
-        self.ptr_mut().offset(i as isize)
+        let shape = self.shape();
+        if shape.0.value() * shape.1.value() == 0 {
+            // If we have a zero-size matrix, our pointer must
+            // be dangling. Instead of calling 'offset', we
+            // just re-use our pointer, since actually using
+            // it would be undefined behavior
+            self.ptr_mut()
+        } else {
+            self.ptr_mut().offset(i as isize)
+        }
     }
 
     /// Gets the mutable address of the i-th matrix component without performing bound-checking.

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -72,16 +72,7 @@ pub unsafe trait Storage<N: Scalar, R: Dim, C: Dim = U1>: Debug + Sized {
     /// Gets the address of the i-th matrix component without performing bound-checking.
     #[inline]
     unsafe fn get_address_unchecked_linear(&self, i: usize) -> *const N {
-        let shape = self.shape();
-        if shape.0.value() * shape.1.value() == 0 {
-            // If we have a zero-size matrix, our pointer must
-            // be dangling. Instead of calling 'offset', we
-            // just re-use our pointer, since actually using
-            // it would be undefined behavior
-            self.ptr()
-        } else {
-            self.ptr().offset(i as isize)
-        }
+        self.ptr().wrapping_offset(i as isize)
     }
 
     /// Gets the address of the i-th matrix component without performing bound-checking.
@@ -133,16 +124,7 @@ pub unsafe trait StorageMut<N: Scalar, R: Dim, C: Dim = U1>: Storage<N, R, C> {
     /// Gets the mutable address of the i-th matrix component without performing bound-checking.
     #[inline]
     unsafe fn get_address_unchecked_linear_mut(&mut self, i: usize) -> *mut N {
-        let shape = self.shape();
-        if shape.0.value() * shape.1.value() == 0 {
-            // If we have a zero-size matrix, our pointer must
-            // be dangling. Instead of calling 'offset', we
-            // just re-use our pointer, since actually using
-            // it would be undefined behavior
-            self.ptr_mut()
-        } else {
-            self.ptr_mut().offset(i as isize)
-        }
+        self.ptr_mut().wrapping_offset(i as isize)
     }
 
     /// Gets the mutable address of the i-th matrix component without performing bound-checking.


### PR DESCRIPTION
When creating a matrix with only one zero dimension, we end up with a
matrix with a total size of zero, but a non-zero stride for elements.
While such a matrix can never actually have any elements, we need to be
careful with how we use the pointer associated with it.

Since such a pointer will always be dangling, it can never be used with `ptr.offset`,
which requires that the pointer be in-bounds or one passed the end of an
allocation. Violating this results in undefined behavior.

This commit adds in checks before the uses of `ptr.offset`. If we ever
need to offset from a pointer when our actual allocation size is zero,
we skip offsetting, and return the original pointer. This is fine
because any actual use of the original or offsetted pointer would
already be undefined behavior - we shoul never be trying to dereference
the pointer associated with a zero-size matrix.

This issue was caught be running `cargo miri test` on the project.