### PR TITLE
Correct Schur decomposition for 2x2 matrices

### DIFF
--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -413,6 +413,7 @@ where
             let inv_rot = rot.inverse();
             inv_rot.rotate(&mut m);
             rot.rotate_rows(&mut m);
+            m[(1, 0)] = N::zero();
 
             if compute_q {
                 // XXX: we have to build the matrix manually because


### PR DESCRIPTION
Due to rounding and possible loss of precision the lower left element of the 2x2 matrix
may be different from zero.

This optimization should fix issue #655. 

An example for this optimization can be found in Eigen code at the following [link](https://bitbucket.org/eigen/eigen/src/b58ba8bfb096e616cfe2fc39d1d94780174df809/Eigen/src/Eigenvalues/RealSchur.h#lines-419).