### PR TITLE
Cholupdate

### DIFF
--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -154,8 +154,7 @@ where
         DefaultAllocator: Allocator<N, R2, U1>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
-        // for a description of the operation, see https://en.wikipedia.org/wiki/Cholesky_decomposition#Updating_the_decomposition
-        // heavily inspired by Eigen's implementation https://eigen.tuxfamily.org/dox/LLT_8h_source.html
+        // heavily inspired by Eigen's `llt_rank_update_lower` implementation https://eigen.tuxfamily.org/dox/LLT_8h_source.html
         let n = x.nrows();
         let mut x = x.clone_owned();
         let mut beta = crate::one::<N::RealField>();

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -151,7 +151,7 @@ where
     /// TODO rewrite comment (current version is taken verbatim from eigen)
     /// TODO insures that code is correct for complex numbers, eigen uses abs2 and conj
     /// https://eigen.tuxfamily.org/dox/LLT_8h_source.html
-    pub fn rank_one_update<R2: Dim, C2: Dim, S2>(&mut self, x: &Matrix<N, R2, U1, S2>, sigma: N)
+    pub fn rank_one_update<R2: Dim, S2>(&mut self, x: &Matrix<N, R2, U1, S2>, sigma: N)
     where
         S2: Storage<N, R2, U1>,
         DefaultAllocator: Allocator<N, R2, U1>,

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -216,18 +216,21 @@ where
         let mut chol= self.chol.clone().insert_column(j, N::zero()).insert_row(j, N::zero());
 
         // update the jth row
-        let top_left_corner = chol.slice_range(..j-1, ..j-1);
-        let colj_minus = col.rows_range(..j-1);
+        let top_left_corner = chol.slice_range(..j, ..j);
+        let colj_minus = col.rows_range(..j);
         let rowj = top_left_corner.solve_lower_triangular(&colj_minus).unwrap().adjoint(); // TODO both the row and its adjoint seem to be usefull
-        chol.slice_range_mut(j, ..j-1).copy_from(&rowj);
+        chol.slice_range_mut(j, ..j).copy_from(&rowj);
+
+        // TODO
+        //println!("dotc:{} norm2:{}", rowj.dotc(&rowj), rowj.norm_squared());
 
         // update the center element
-        let center_element = N::sqrt(col[j] + rowj.dot(&rowj.adjoint())); // TODO is there a better way to multiply a vector by its adjoint ? norm_squared ?
+        let center_element = N::sqrt(col[j] - rowj.dotc(&rowj) );
         chol[(j,j)] = center_element;
 
         // update the jth column
         let colj_plus = col.rows_range(j+1..);
-        let bottom_left_corner = chol.slice_range(j+1.., ..j-1);
+        let bottom_left_corner = chol.slice_range(j+1.., ..j);
         let colj = (colj_plus - bottom_left_corner*rowj.adjoint()) / center_element; // TODO that can probably be done with a single optimized operation
         chol.slice_range_mut(j+1.., j).copy_from(&colj);
 

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -8,6 +8,7 @@ use crate::base::{DefaultAllocator, Matrix, MatrixMN, MatrixN, SquareMatrix};
 use crate::constraint::{SameNumberOfRows, ShapeConstraint};
 use crate::dimension::{Dim, DimSub, Dynamic, U1};
 use crate::storage::{Storage, StorageMut};
+use crate::RealField;
 
 /// The Cholesky decomposition of a symmetric-definite-positive matrix.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -151,12 +152,18 @@ where
     /// TODO rewrite comment (current version is taken verbatim from eigen)
     /// TODO insures that code is correct for complex numbers, eigen uses abs2 and conj
     /// https://eigen.tuxfamily.org/dox/LLT_8h_source.html
-    pub fn rank_one_update<R2: Dim, S2>(&mut self, x: &Matrix<N, R2, U1, S2>, sigma: N)
-    where
+    /// TODO insure that sigma is a real
+    pub fn rank_one_update<R2: Dim, S2, N2: RealField>(
+        &mut self,
+        x: &Matrix<N, R2, U1, S2>,
+        sigma: N2,
+    ) where
+        N: From<N2>,
         S2: Storage<N, R2, U1>,
         DefaultAllocator: Allocator<N, R2, U1>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
+        let sigma = <N>::from(sigma);
         let n = x.nrows();
         let mut temp = x.clone_owned();
         for k in 0..n {

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -242,10 +242,10 @@ where
         Cholesky { chol }
     }
 
-    /// Given the Cholesky decomposition of a matrix `M`, a scalar `sigma` and a vector `v`,
+    /// Given the Cholesky decomposition of a matrix `M`, a scalar `sigma` and a vector `x`,
     /// performs a rank one update such that we end up with the decomposition of `M + sigma * (x * x.adjoint())`.
     ///
-    /// This helper method is calling for by `rank_one_update` but also `insert_column` and `remove_column`
+    /// This helper method is called by `rank_one_update` but also `insert_column` and `remove_column`
     /// where it is used on a square slice of the decomposition
     fn xx_rank_one_update<Dm, Sm, Rx, Sx>(chol : &mut Matrix<N, Dm, Dm, Sm>, x: &mut Vector<N, Rx, Sx>, sigma: N::RealField)
         where

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -156,6 +156,11 @@ where
     {
         // heavily inspired by Eigen's `llt_rank_update_lower` implementation https://eigen.tuxfamily.org/dox/LLT_8h_source.html
         let n = x.nrows();
+        assert_eq!(
+            n,
+            self.chol.nrows(),
+            "The input vector must be of the same size as the factorized matrix."
+        );
         let mut x = x.clone_owned();
         let mut beta = crate::one::<N::RealField>();
         for j in 0..n {

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -147,7 +147,7 @@ where
     }
 
     /// Given the Cholesky decomposition of a matrix `M`, a scalar `sigma` and a vector `v`,
-    /// performs a rank one update such that we end up with the decomposition of `M + sigma * v*v^*`.
+    /// performs a rank one update such that we end up with the decomposition of `M + sigma * v*v.adjoint()`.
     pub fn rank_one_update<R2: Dim, S2>(&mut self, x: &Matrix<N, R2, U1, S2>, sigma: N::RealField)
     where
         S2: Storage<N, R2, U1>,
@@ -156,27 +156,31 @@ where
     {
         // for a description of the operation, see https://en.wikipedia.org/wiki/Cholesky_decomposition#Updating_the_decomposition
         // heavily inspired by Eigen's implementation https://eigen.tuxfamily.org/dox/LLT_8h_source.html
-        // TODO use unsafe { *matrix.get_unchecked((j, j)) }
         let n = x.nrows();
-        let mut temp = x.clone_owned();
+        let mut x = x.clone_owned();
         let mut beta = crate::one::<N::RealField>();
         for j in 0..n {
-            let ljj = N::real(self.chol[(j, j)]);
-            let dj = ljj * ljj;
-            let wj = temp[j];
-            let swj2 = sigma * N::modulus_squared(wj);
-            let gamma = dj * beta + swj2;
-            let nljj = (dj + swj2 / beta).sqrt();
-            self.chol[(j, j)] = N::from_real(nljj);
-            beta += swj2 / dj;
+            let diag = N::real(unsafe { *self.chol.get_unchecked((j, j)) });
+            let diag2 = diag * diag;
+            let xj = unsafe { *x.get_unchecked(j) };
+            let sigma_xj2 = sigma * N::modulus_squared(xj);
+            let gamma = diag2 * beta + sigma_xj2;
+            let new_diag = (diag2 + sigma_xj2 / beta).sqrt();
+            unsafe { *self.chol.get_unchecked_mut((j, j)) = N::from_real(new_diag) };
+            beta += sigma_xj2 / diag2;
             // Update the terms of L
             if j < n {
-                for k in (j + 1)..n {
-                    temp[k] -= (wj / N::from_real(ljj)) * self.chol[(k, j)];
-                    if gamma != crate::zero::<N::RealField>() {
-                        self.chol[(k, j)] = N::from_real(nljj / ljj) * self.chol[(k, j)]
-                            + (N::from_real(nljj * sigma / gamma) * N::conjugate(wj)) * temp[k];
-                    }
+                let mut xjplus = x.rows_range_mut(j + 1..);
+                let mut col_j = self.chol.slice_range_mut(j + 1.., j);
+                // temp_jplus -= (wj / N::from_real(diag)) * col_j;
+                xjplus.axpy(-xj / N::from_real(diag), &col_j, N::one());
+                if gamma != crate::zero::<N::RealField>() {
+                    // col_j = N::from_real(nljj / diag) * col_j  + (N::from_real(nljj * sigma / gamma) * N::conjugate(wj)) * temp_jplus;
+                    col_j.axpy(
+                        N::from_real(new_diag * sigma / gamma) * N::conjugate(xj),
+                        &xjplus,
+                        N::from_real(new_diag / diag),
+                    );
                 }
             }
         }

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -149,48 +149,17 @@ where
 
     /// Given the Cholesky decomposition of a matrix `M`, a scalar `sigma` and a vector `v`,
     /// performs a rank one update such that we end up with the decomposition of `M + sigma * v*v.adjoint()`.
+    #[inline]
     pub fn rank_one_update<R2: Dim, S2>(&mut self, x: &Vector<N, R2, S2>, sigma: N::RealField)
     where
         S2: Storage<N, R2, U1>,
         DefaultAllocator: Allocator<N, R2, U1>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
-        // heavily inspired by Eigen's `llt_rank_update_lower` implementation https://eigen.tuxfamily.org/dox/LLT_8h_source.html
-        let n = x.nrows();
-        assert_eq!(
-            n,
-            self.chol.nrows(),
-            "The input vector must be of the same size as the factorized matrix."
-        );
-        let mut x = x.clone_owned();
-        let mut beta = crate::one::<N::RealField>();
-        for j in 0..n {
-            // updates the diagonal
-            let diag = N::real(unsafe { *self.chol.get_unchecked((j, j)) });
-            let diag2 = diag * diag;
-            let xj = unsafe { *x.get_unchecked(j) };
-            let sigma_xj2 = sigma * N::modulus_squared(xj);
-            let gamma = diag2 * beta + sigma_xj2;
-            let new_diag = (diag2 + sigma_xj2 / beta).sqrt();
-            unsafe { *self.chol.get_unchecked_mut((j, j)) = N::from_real(new_diag) };
-            beta += sigma_xj2 / diag2;
-            // updates the terms of L
-            let mut xjplus = x.rows_range_mut(j + 1..);
-            let mut col_j = self.chol.slice_range_mut(j + 1.., j);
-            // temp_jplus -= (wj / N::from_real(diag)) * col_j;
-            xjplus.axpy(-xj / N::from_real(diag), &col_j, N::one());
-            if gamma != crate::zero::<N::RealField>() {
-                // col_j = N::from_real(nljj / diag) * col_j  + (N::from_real(nljj * sigma / gamma) * N::conjugate(wj)) * temp_jplus;
-                col_j.axpy(
-                    N::from_real(new_diag * sigma / gamma) * N::conjugate(xj),
-                    &xjplus,
-                    N::from_real(new_diag / diag),
-                );
-            }
-        }
+        rank_one_update(&mut self.chol, x, sigma)
     }
 
-    /// Updates the decomposition such that we get the decomposition of a matrix with the given column `c` in the `j`th position.
+    /// Updates the decomposition such that we get the decomposition of a matrix with the given column `col` in the `j`th position.
     /// Since the matrix is square, an identical row will be added in the `j`th row.
     pub fn insert_column<R2, S2>(
         self,
@@ -206,37 +175,32 @@ where
     {
         // for an explanation of the formulas, see https://en.wikipedia.org/wiki/Cholesky_decomposition#Updating_the_decomposition
         let n = col.nrows();
-        assert_eq!(
-            n,
-            self.chol.nrows() + 1,
-            "The new column must have the size of the factored matrix plus one."
-        );
+        assert_eq!(n, self.chol.nrows() + 1, "The new column must have the size of the factored matrix plus one.");
         assert!(j < n, "j needs to be within the bound of the new matrix.");
+
         // TODO what is the fastest way to produce the new matrix ?
         let mut chol= self.chol.clone().insert_column(j, N::zero()).insert_row(j, N::zero());
 
         // update the jth row
-        let top_left_corner = chol.slice_range(..j, ..j);
-        let colj_minus = col.rows_range(..j);
-        let rowj = top_left_corner.solve_lower_triangular(&colj_minus).unwrap().adjoint(); // TODO both the row and its adjoint seem to be usefull
-        chol.slice_range_mut(j, ..j).copy_from(&rowj);
-
-        // TODO
-        //println!("dotc:{} norm2:{}", rowj.dotc(&rowj), rowj.norm_squared());
+        let top_left_corner = self.chol.slice_range(..j, ..j);
+        let col_jminus = col.rows_range(..j);
+        let new_rowj_adjoint = top_left_corner.solve_lower_triangular(&col_jminus).expect("Cholesky::insert_column : Unable to solve lower triangular system!");
+        new_rowj_adjoint.adjoint_to(&mut chol.slice_range_mut(j, ..j));
 
         // update the center element
-        let center_element = N::sqrt(col[j] - rowj.dotc(&rowj) );
+        let center_element = N::sqrt(col[j] - N::from_real(new_rowj_adjoint.norm_squared()));
         chol[(j,j)] = center_element;
 
         // update the jth column
-        let colj_plus = col.rows_range(j+1..);
-        let bottom_left_corner = chol.slice_range(j+1.., ..j);
-        let colj = (colj_plus - bottom_left_corner*rowj.adjoint()) / center_element; // TODO that can probably be done with a single optimized operation
-        chol.slice_range_mut(j+1.., j).copy_from(&colj);
+        let bottom_left_corner = self.chol.slice_range(j.., ..j);
+        // new_colj = (col_jplus - bottom_left_corner * new_rowj.adjoint()) / center_element;
+        let mut new_colj = col.rows_range(j+1..).clone_owned();
+        new_colj.gemm(-N::one() / center_element, &bottom_left_corner, &new_rowj_adjoint, N::one() / center_element );
+        chol.slice_range_mut(j+1.., j).copy_from(&new_colj);
 
         // update the bottom right corner
         let mut bottom_right_corner = chol.slice_range_mut(j+1.., j+1..);
-        rank_one_update_helper(&mut bottom_right_corner, &colj, -N::real(N::one()));
+        rank_one_update(&mut bottom_right_corner, &new_colj, -N::real(N::one()));
 
         Cholesky { chol }
     }
@@ -254,13 +218,14 @@ where
         let n = self.chol.nrows();
         assert!(n > 0, "The matrix needs at least one column.");
         assert!(j < n, "j needs to be within the bound of the matrix.");
+
         // TODO what is the fastest way to produce the new matrix ?
         let mut chol= self.chol.clone().remove_column(j).remove_row(j);
 
         // updates the bottom right corner
-        let mut corner = chol.slice_range_mut(j.., j..);
-        let colj = self.chol.slice_range(j+1.., j);
-        rank_one_update_helper(&mut corner, &colj, N::real(N::one()));
+        let mut bottom_right_corner = chol.slice_range_mut(j.., j..);
+        let old_colj = self.chol.slice_range(j+1.., j);
+        rank_one_update(&mut bottom_right_corner, &old_colj, N::real(N::one()));
 
         Cholesky { chol }
     }
@@ -281,7 +246,10 @@ where
 
 /// Given the Cholesky decomposition of a matrix `M`, a scalar `sigma` and a vector `v`,
 /// performs a rank one update such that we end up with the decomposition of `M + sigma * v*v.adjoint()`.
-fn rank_one_update_helper<N, D, S, Rx, Sx>(chol : &mut Matrix<N, D, D, S>, x: &Vector<N, Rx, Sx>, sigma: N::RealField)
+///
+/// This helper method is calling for by `rank_one_update` but also `insert_column` and `remove_column`
+/// where it is used on a square slice of the decomposition
+fn rank_one_update<N, D, S, Rx, Sx>(chol : &mut Matrix<N, D, D, S>, x: &Vector<N, Rx, Sx>, sigma: N::RealField)
     where
         N: ComplexField,
         D: Dim,

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -147,12 +147,10 @@ where
         res
     }
 
-    /// Performs a rank one update of the current decomposition.
-    /// If `M = L * L^T` before the rank one update, then after it we have `L*L^T = M + sigma * v*v^T` where v must be a vector of same dimension.
-    /// TODO rewrite comment (current version is taken verbatim from eigen)
+    /// Given the Cholesky decomposition of a matrix `M`, a scalar `sigma` and a vector `v`,
+    /// performs a rank one update such that we end up with the decomposition of `M + sigma * v*v^*`.
     /// TODO insures that code is correct for complex numbers, eigen uses abs2 and conj
     /// https://eigen.tuxfamily.org/dox/LLT_8h_source.html
-    /// TODO insure that sigma is a real
     pub fn rank_one_update<R2: Dim, S2, N2: RealField>(
         &mut self,
         x: &Matrix<N, R2, U1, S2>,

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -6,7 +6,7 @@ use alga::general::ComplexField;
 use crate::allocator::Allocator;
 use crate::base::{DefaultAllocator, Matrix, MatrixMN, MatrixN, SquareMatrix};
 use crate::constraint::{SameNumberOfRows, ShapeConstraint};
-use crate::dimension::{Dim, DimAdd, DimSum, DimSub, Dynamic, U1};
+use crate::dimension::{Dim, DimAdd, DimSum, DimDiff, DimSub, Dynamic, U1};
 use crate::storage::{Storage, StorageMut};
 use crate::base::allocator::Reallocator;
 
@@ -212,6 +212,26 @@ where
         assert!(j < n, "j needs to be within the bound of the new matrix.");
         // TODO what is the fastest way to produce the new matrix ?
         let chol= self.chol.insert_column(j, N::zero()).insert_row(j, N::zero());
+
+        // TODO see https://en.wikipedia.org/wiki/Cholesky_decomposition#Updating_the_decomposition
+        unimplemented!();
+        Cholesky { chol }
+    }
+
+    /// Updates the decomposition such that we get the decomposition of the factored matrix with its `j`th column removed.
+    /// Since the matrix is square, the `j`th row will also be removed.
+    pub fn remove_column(
+        self,
+        j: usize,
+    ) -> Cholesky<N, DimDiff<D, U1>>
+        where
+            D: DimSub<U1>,
+            DefaultAllocator: Reallocator<N, D, D, D, DimDiff<D, U1>> + Reallocator<N, D, DimDiff<D, U1>, DimDiff<D, U1>, DimDiff<D, U1>>,
+    {
+        let n = self.chol.nrows();
+        assert!(j < n, "j needs to be within the bound of the matrix.");
+        // TODO what is the fastest way to produce the new matrix ?
+        let chol= self.chol.remove_column(j).remove_row(j);
 
         // TODO see https://en.wikipedia.org/wiki/Cholesky_decomposition#Updating_the_decomposition
         unimplemented!();

--- a/src/linalg/solve.rs
+++ b/src/linalg/solve.rs
@@ -15,7 +15,7 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         b: &Matrix<N, R2, C2, S2>,
     ) -> Option<MatrixMN<N, R2, C2>>
     where
-        S2: StorageMut<N, R2, C2>,
+        S2: Storage<N, R2, C2>,
         DefaultAllocator: Allocator<N, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
@@ -35,7 +35,7 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         b: &Matrix<N, R2, C2, S2>,
     ) -> Option<MatrixMN<N, R2, C2>>
     where
-        S2: StorageMut<N, R2, C2>,
+        S2: Storage<N, R2, C2>,
         DefaultAllocator: Allocator<N, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
@@ -191,7 +191,7 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         b: &Matrix<N, R2, C2, S2>,
     ) -> Option<MatrixMN<N, R2, C2>>
         where
-            S2: StorageMut<N, R2, C2>,
+            S2: Storage<N, R2, C2>,
             DefaultAllocator: Allocator<N, R2, C2>,
             ShapeConstraint: SameNumberOfRows<R2, D>,
     {
@@ -211,7 +211,7 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         b: &Matrix<N, R2, C2, S2>,
     ) -> Option<MatrixMN<N, R2, C2>>
         where
-            S2: StorageMut<N, R2, C2>,
+            S2: Storage<N, R2, C2>,
             DefaultAllocator: Allocator<N, R2, C2>,
             ShapeConstraint: SameNumberOfRows<R2, D>,
     {
@@ -273,7 +273,7 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         b: &Matrix<N, R2, C2, S2>,
     ) -> Option<MatrixMN<N, R2, C2>>
         where
-            S2: StorageMut<N, R2, C2>,
+            S2: Storage<N, R2, C2>,
             DefaultAllocator: Allocator<N, R2, C2>,
             ShapeConstraint: SameNumberOfRows<R2, D>,
     {
@@ -293,7 +293,7 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         b: &Matrix<N, R2, C2, S2>,
     ) -> Option<MatrixMN<N, R2, C2>>
         where
-            S2: StorageMut<N, R2, C2>,
+            S2: Storage<N, R2, C2>,
             DefaultAllocator: Allocator<N, R2, C2>,
             ShapeConstraint: SameNumberOfRows<R2, D>,
     {

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -100,7 +100,7 @@ macro_rules! gen_tests(
                 }
 
                 fn cholesky_insert_column(n: usize) -> bool {
-                    let n = n.max(1).min(5);
+                    let n = n.max(1).min(50);
                     let j = random::<usize>() % n;
                     let m_updated = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
 

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -79,10 +79,13 @@ macro_rules! gen_tests(
                 }
 
                 fn cholesky_rank_one_update(_n: usize) -> bool {
-                    let mut m = RandomSDP::new(U4, || random::<$scalar>().0).unwrap();
-                    let x = Vector4::<$scalar>::new_random().map(|e| e.0);
-                    let sigma = random::<$scalar>().0; // random::<$scalar>().0;
-                    let one = sigma*0. + 1.; // TODO this is dirty but $scalar appears to not be a scalar type
+                    use nalgebra::dimension::U3;
+                    use nalgebra::Vector3;
+                    let mut m = RandomSDP::new(U3, || random::<$scalar>().0).unwrap();
+                    let x = Vector3::<$scalar>::new_random().map(|e| e.0);
+                    let mut sigma = random::<$scalar>().0; // random::<$scalar>().0;
+                    let one = sigma*0. + 1.; // TODO this is dirty but $scalar appears to not be a scalar type in this file
+                    sigma = one; // TODO placeholder
 
                     // updates cholesky decomposition and reconstructs m
                     let mut chol = m.clone().cholesky().unwrap();
@@ -90,9 +93,11 @@ macro_rules! gen_tests(
                     let m_chol_updated = chol.l() * chol.l().adjoint();
 
                     // updates m manually
-                    m.syger(sigma, &x, &x, one); // m += sigma * x * x.adjoint()
+                    m.ger(sigma, &x, &x, one); // m += sigma * x * x.adjoint()
 
-                    println!("m : {:?}", m);
+                    println!("sigma : {}", sigma);
+                    println!("m updated : {}", m);
+                    println!("chol : {}", m_chol_updated);
 
                     relative_eq!(m, m_chol_updated, epsilon = 1.0e-7)
                 }

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -100,7 +100,7 @@ macro_rules! gen_tests(
                 }
 
                 fn cholesky_insert_column(n: usize) -> bool {
-                    let n = n.max(1).min(50);
+                    let n = n.max(1).min(10);
                     let j = random::<usize>() % n;
                     let m_updated = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
 
@@ -112,15 +112,11 @@ macro_rules! gen_tests(
                     let chol = m.clone().cholesky().unwrap().insert_column(j, &col);
                     let m_chol_updated = chol.l() * chol.l().adjoint();
 
-                    println!("n={} j={}", n, j);
-                    println!("chol updated:{}", m_chol_updated);
-                    println!("m updated:{}", m_updated);
-
                     relative_eq!(m_updated, m_chol_updated, epsilon = 1.0e-7)
                 }
 
                 fn cholesky_remove_column(n: usize) -> bool {
-                    let n = n.max(1).min(5);
+                    let n = n.max(1).min(10);
                     let j = random::<usize>() % n;
                     let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
 

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -79,10 +79,8 @@ macro_rules! gen_tests(
                 }
 
                 fn cholesky_rank_one_update(_n: usize) -> bool {
-                    use nalgebra::dimension::U3;
-                    use nalgebra::Vector3;
-                    let mut m = RandomSDP::new(U3, || random::<$scalar>().0).unwrap();
-                    let x = Vector3::<$scalar>::new_random().map(|e| e.0);
+                    let mut m = RandomSDP::new(U4, || random::<$scalar>().0).unwrap();
+                    let x = Vector4::<$scalar>::new_random().map(|e| e.0);
 
                     // TODO this is dirty but $scalar appears to not be a scalar type in this file
                     let zero = random::<$scalar>().0 * 0.;
@@ -96,11 +94,7 @@ macro_rules! gen_tests(
                     let m_chol_updated = chol.l() * chol.l().adjoint();
 
                     // updates m manually
-                    m.ger(sigma_scalar, &x, &x, one); // m += sigma * x * x.adjoint()
-
-                    println!("sigma : {}", sigma);
-                    println!("m updated : {}", m);
-                    println!("chol : {}", m_chol_updated);
+                    m.gerc(sigma_scalar, &x, &x, one); // m += sigma * x * x.adjoint()
 
                     relative_eq!(m, m_chol_updated, epsilon = 1.0e-7)
                 }

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -98,6 +98,25 @@ macro_rules! gen_tests(
 
                     relative_eq!(m, m_chol_updated, epsilon = 1.0e-7)
                 }
+
+                fn cholesky_remove_column(n: usize) -> bool {
+                    let n = n.max(1).min(5);
+                    let j = random::<usize>() % n;
+                    let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+
+                    // remove column from cholesky decomposition and rebuild m
+                    let chol = m.clone().cholesky().unwrap().remove_column(j);
+                    let m_chol_updated = chol.l() * chol.l().adjoint();
+
+                    // remove column from m
+                    let m_updated = m.remove_column(j).remove_row(j);
+
+                    println!("n={} j={}", n, j);
+                    println!("chol:{}", m_chol_updated);
+                    println!("m up:{}", m_updated);
+
+                    relative_eq!(m_updated, m_chol_updated, epsilon = 1.0e-7)
+                }
             }
         }
     }

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -82,13 +82,13 @@ macro_rules! gen_tests(
                     let mut m = RandomSDP::new(U4, || random::<$scalar>().0).unwrap();
                     let x = Vector4::<$scalar>::new_random().map(|e| e.0);
 
-                    // TODO this is dirty but $scalar appears to not be a scalar type in this file
+                    // this is dirty but $scalar is not a scalar type (its a Rand) in this file
                     let zero = random::<$scalar>().0 * 0.;
                     let one = zero + 1.;
                     let sigma = random::<f64>(); // needs to be a real
                     let sigma_scalar = zero + sigma;
 
-                    // updates cholesky decomposition and reconstructs m
+                    // updates cholesky decomposition and reconstructs m updated
                     let mut chol = m.clone().cholesky().unwrap();
                     chol.rank_one_update(&x, sigma);
                     let m_chol_updated = chol.l() * chol.l().adjoint();

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -99,6 +99,26 @@ macro_rules! gen_tests(
                     relative_eq!(m, m_chol_updated, epsilon = 1.0e-7)
                 }
 
+                fn cholesky_insert_column(n: usize) -> bool {
+                    let n = n.max(1).min(5);
+                    let j = random::<usize>() % n;
+                    let m_updated = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+
+                    // build m and col from m_updated
+                    let col = m_updated.column(j);
+                    let m = m_updated.clone().remove_column(j).remove_row(j);
+
+                    // remove column from cholesky decomposition and rebuild m
+                    let chol = m.clone().cholesky().unwrap().insert_column(j, &col);
+                    let m_chol_updated = chol.l() * chol.l().adjoint();
+
+                    println!("n={} j={}", n, j);
+                    println!("chol updated:{}", m_chol_updated);
+                    println!("m updated:{}", m_updated);
+
+                    relative_eq!(m_updated, m_chol_updated, epsilon = 1.0e-7)
+                }
+
                 fn cholesky_remove_column(n: usize) -> bool {
                     let n = n.max(1).min(5);
                     let j = random::<usize>() % n;
@@ -110,10 +130,6 @@ macro_rules! gen_tests(
 
                     // remove column from m
                     let m_updated = m.remove_column(j).remove_row(j);
-
-                    println!("n={} j={}", n, j);
-                    println!("chol:{}", m_chol_updated);
-                    println!("m up:{}", m_updated);
 
                     relative_eq!(m_updated, m_chol_updated, epsilon = 1.0e-7)
                 }

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -1,6 +1,5 @@
 #![cfg(all(feature = "arbitrary", feature = "debug"))]
 
-
 macro_rules! gen_tests(
     ($module: ident, $scalar: ty) => {
         mod $module {
@@ -77,6 +76,22 @@ macro_rules! gen_tests(
                     let id2 = &m1 * &m;
 
                     id1.is_identity(1.0e-7) && id2.is_identity(1.0e-7)
+                }
+
+                fn cholesky_rank_one_update(_n: usize) -> bool {
+                    let m = RandomSDP::new(U4, || random::<$scalar>().0).unwrap();
+                    let x = Vector4::<$scalar>::new_random().map(|e| e.0);
+                    let sigma : $scalar = 1.;
+
+                    // updates m manually
+                    let m_updated = m + sigma * x * x.transpose();
+
+                    // updates cholesky deomposition and reconstruct m
+                    let mut chol = m.clone().cholesky().unwrap();
+                    chol.rank_one_update(x, sigma);
+                    let m_chol_updated = chol.l() * chol.l().transpose();
+
+                    relative_eq!(m_updated, m_chol_updated, epsilon = 1.0e-7)
                 }
             }
         }

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -109,7 +109,7 @@ macro_rules! gen_tests(
                     let m = m_updated.clone().remove_column(j).remove_row(j);
 
                     // remove column from cholesky decomposition and rebuild m
-                    let chol = m.clone().cholesky().unwrap().insert_column(j, &col);
+                    let chol = m.clone().cholesky().unwrap().insert_column(j, col);
                     let m_chol_updated = chol.l() * chol.l().adjoint();
 
                     relative_eq!(m_updated, m_chol_updated, epsilon = 1.0e-7)

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -83,9 +83,12 @@ macro_rules! gen_tests(
                     use nalgebra::Vector3;
                     let mut m = RandomSDP::new(U3, || random::<$scalar>().0).unwrap();
                     let x = Vector3::<$scalar>::new_random().map(|e| e.0);
-                    let mut sigma = random::<$scalar>().0; // random::<$scalar>().0;
-                    let one = sigma*0. + 1.; // TODO this is dirty but $scalar appears to not be a scalar type in this file
-                    sigma = one; // TODO placeholder
+
+                    // TODO this is dirty but $scalar appears to not be a scalar type in this file
+                    let zero = random::<$scalar>().0 * 0.;
+                    let one = zero + 1.;
+                    let sigma = random::<f64>(); // needs to be a real
+                    let sigma_scalar = zero + sigma;
 
                     // updates cholesky decomposition and reconstructs m
                     let mut chol = m.clone().cholesky().unwrap();
@@ -93,7 +96,7 @@ macro_rules! gen_tests(
                     let m_chol_updated = chol.l() * chol.l().adjoint();
 
                     // updates m manually
-                    m.ger(sigma, &x, &x, one); // m += sigma * x * x.adjoint()
+                    m.ger(sigma_scalar, &x, &x, one); // m += sigma * x * x.adjoint()
 
                     println!("sigma : {}", sigma);
                     println!("m updated : {}", m);


### PR DESCRIPTION
Added code and test for cholesky decomposition update (see [issue 652](https://github.com/rustsim/nalgebra/issues/652)).

Also relaxed some traits from `StorageMut` to `Storage` in `solve.rs` methods (following [issue 667](https://github.com/rustsim/nalgebra/issues/667)).

My code to create a new matrix with one more/less row+column should be reviewed : it is correct but there is probably a more efficient way to do that using nalgebra internals.

The `insert_column` and `insert_row` methods take `&self` (where methods with the same name elsewhere in nalgebra take `self`) as it is the minimum required by the current implementation : it could be changed for homogenization purposes.