### PR TITLE
Import IsaacRng from rand_isaac instead of rand.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ pest_derive    = { version = "2.0", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 rand_xorshift = "0.2"
+rand_isaac = "0.2"
 ### Uncomment this line before running benchmarks.
 ### We can't just let this uncommented because that would break
 ### compilation for #[no-std] because of the terrible Cargo bug

--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -1,5 +1,6 @@
 use na::{DMatrix, DVector, Matrix2, Matrix3, Matrix4, MatrixN, Vector2, Vector3, Vector4, U10};
-use rand::{IsaacRng, Rng};
+use rand::Rng;
+use rand_isaac::IsaacRng;
 use std::ops::{Add, Div, Mul, Sub};
 
 #[path = "../common/macros.rs"]

--- a/benches/core/vector.rs
+++ b/benches/core/vector.rs
@@ -1,5 +1,6 @@
 use na::{DVector, Vector2, Vector3, Vector4, VectorN};
-use rand::{IsaacRng, Rng};
+use rand::Rng;
+use rand_isaac::IsaacRng;
 use std::ops::{Add, Div, Mul, Sub};
 use typenum::U10000;
 

--- a/benches/geometry/quaternion.rs
+++ b/benches/geometry/quaternion.rs
@@ -1,5 +1,6 @@
 use na::{Quaternion, UnitQuaternion, Vector3};
-use rand::{IsaacRng, Rng};
+use rand::Rng;
+use rand_isaac::IsaacRng;
 use std::ops::{Add, Div, Mul, Sub};
 
 #[path = "../common/macros.rs"]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate nalgebra as na;
 extern crate rand;
+extern crate rand_isaac;
 extern crate test;
 extern crate typenum;
 
@@ -10,7 +11,8 @@ extern crate typenum;
 extern crate criterion;
 
 use na::DMatrix;
-use rand::{IsaacRng, Rng};
+use rand::Rng;
+use rand_isaac::IsaacRng;
 
 pub mod core;
 pub mod geometry;


### PR DESCRIPTION
The rand crate removed IsaacRng in the 0.5 -> 0.6 transition, so the benchmarks that use it haven't compiled since 9c37c512039059281b210521cfd53e931f5fa0b5.