### PR TITLE
Implement Extend<&N> for VecStorage.

### DIFF
--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -268,6 +268,21 @@ impl<N, R: Dim> Extend<N> for VecStorage<N, R, Dynamic>
     }
 }
 
+impl<'a, N: 'a + Copy, R: Dim> Extend<&'a N> for VecStorage<N, R, Dynamic>
+{
+    /// Extends the number of columns of the `VecStorage` with elements
+    /// from the given iterator.
+    ///
+    /// # Panics
+    /// This function panics if the number of elements yielded by the
+    /// given iterator is not a multiple of the number of rows of the
+    /// `VecStorage`.
+    fn extend<I: IntoIterator<Item=&'a N>>(&mut self, iter: I)
+    {
+        self.extend(iter.into_iter().copied())
+    }
+}
+
 impl<N, R, RV, SV> Extend<Vector<N, RV, SV>> for VecStorage<N, R, Dynamic>
 where
     N: Scalar + Copy,


### PR DESCRIPTION
`Extend<N>` was already implemented, but nalgebra vectors/matrices give
iterators that give `&N`, not `N`, so implementing `Extend<&N>` as well makes
it easier to use.

It seems common practice to do so: The standard library's `Vec` also
implments Extend for both `T` and `&T`.