### PR TITLE
Fix Matrix PartialEq bug and add some generalization

### DIFF
--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -14,7 +14,7 @@ use typenum::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Dim of dynamically-sized algebraic entities.
-#[derive(Clone, Copy, Eq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Dynamic {
     value: usize,
 }
@@ -104,12 +104,6 @@ impl Sub<usize> for Dynamic {
     #[inline]
     fn sub(self, rhs: usize) -> Self {
         Self::new(self.value - rhs)
-    }
-}
-
-impl<T: Dim> PartialEq<T> for Dynamic {
-    fn eq(&self, other: &T) -> bool {
-        self.value() == other.value()
     }
 }
 
@@ -247,6 +241,60 @@ impl NamedDim for typenum::U1 {
     type Name = U1;
 }
 
+macro_rules! named_dimension (
+    ($($D: ident),* $(,)*) => {$(
+        /// A type level dimension.
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+        pub struct $D;
+
+        impl Dim for $D {
+            #[inline]
+            fn try_to_usize() -> Option<usize> {
+                Some(typenum::$D::to_usize())
+            }
+
+            #[inline]
+            fn from_usize(dim: usize) -> Self {
+                assert!(dim == typenum::$D::to_usize(), "Mismatched dimension.");
+                $D
+            }
+
+            #[inline]
+            fn value(&self) -> usize {
+                typenum::$D::to_usize()
+            }
+        }
+
+        impl DimName for $D {
+            type Value = typenum::$D;
+
+            #[inline]
+            fn name() -> Self {
+                $D
+            }
+        }
+
+        impl NamedDim for typenum::$D {
+            type Name = $D;
+        }
+
+        impl IsNotStaticOne for $D { }
+    )*}
+);
+
+// We give explicit names to all Unsigned in [0, 128[
+named_dimension!(
+    U0, /*U1,*/ U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18,
+    U19, U20, U21, U22, U23, U24, U25, U26, U27, U28, U29, U30, U31, U32, U33, U34, U35, U36, U37,
+    U38, U39, U40, U41, U42, U43, U44, U45, U46, U47, U48, U49, U50, U51, U52, U53, U54, U55, U56,
+    U57, U58, U59, U60, U61, U62, U63, U64, U65, U66, U67, U68, U69, U70, U71, U72, U73, U74, U75,
+    U76, U77, U78, U79, U80, U81, U82, U83, U84, U85, U86, U87, U88, U89, U90, U91, U92, U93, U94,
+    U95, U96, U97, U98, U99, U100, U101, U102, U103, U104, U105, U106, U107, U108, U109, U110,
+    U111, U112, U113, U114, U115, U116, U117, U118, U119, U120, U121, U122, U123, U124, U125, U126,
+    U127
+);
+
 // For values greater than U1023, just use the typenum binary representation directly.
 impl<
         A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
@@ -360,63 +408,3 @@ impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Syn
     for UInt<U, B>
 {
 }
-
-macro_rules! named_dimension(
-    ($($D: ident),* $(,)*) => {$(
-        /// A type level dimension.
-        #[derive(Debug, Copy, Clone, Hash, Eq)]
-        #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-        pub struct $D;
-
-        impl Dim for $D {
-            #[inline]
-            fn try_to_usize() -> Option<usize> {
-                Some(typenum::$D::to_usize())
-            }
-
-            #[inline]
-            fn from_usize(dim: usize) -> Self {
-                assert!(dim == typenum::$D::to_usize(), "Mismatched dimension.");
-                $D
-            }
-
-            #[inline]
-            fn value(&self) -> usize {
-                typenum::$D::to_usize()
-            }
-        }
-
-        impl DimName for $D {
-            type Value = typenum::$D;
-
-            #[inline]
-            fn name() -> Self {
-                $D
-            }
-        }
-
-        impl NamedDim for typenum::$D {
-            type Name = $D;
-        }
-
-        impl IsNotStaticOne for $D { }
-
-        impl<T: Dim> PartialEq<T> for $D {
-            fn eq(&self, other: &T) -> bool {
-                self.value() == other.value()
-            }
-        }
-    )*}
-);
-
-// We give explicit names to all Unsigned in [0, 128[
-named_dimension!(
-    U0, /*U1,*/ U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18,
-    U19, U20, U21, U22, U23, U24, U25, U26, U27, U28, U29, U30, U31, U32, U33, U34, U35, U36, U37,
-    U38, U39, U40, U41, U42, U43, U44, U45, U46, U47, U48, U49, U50, U51, U52, U53, U54, U55, U56,
-    U57, U58, U59, U60, U61, U62, U63, U64, U65, U66, U67, U68, U69, U70, U71, U72, U73, U74, U75,
-    U76, U77, U78, U79, U80, U81, U82, U83, U84, U85, U86, U87, U88, U89, U90, U91, U92, U93, U94,
-    U95, U96, U97, U98, U99, U100, U101, U102, U103, U104, U105, U106, U107, U108, U109, U110,
-    U111, U112, U113, U114, U115, U116, U117, U118, U119, U120, U121, U122, U123, U124, U125, U126,
-    U127,
-);

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -14,7 +14,7 @@ use typenum::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Dim of dynamically-sized algebraic entities.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, Debug)]
 pub struct Dynamic {
     value: usize,
 }
@@ -104,6 +104,12 @@ impl Sub<usize> for Dynamic {
     #[inline]
     fn sub(self, rhs: usize) -> Self {
         Self::new(self.value - rhs)
+    }
+}
+
+impl<T: Dim> PartialEq<T> for Dynamic {
+    fn eq(&self, other: &T) -> bool {
+        self.value() == other.value()
     }
 }
 
@@ -244,7 +250,7 @@ impl NamedDim for typenum::U1 {
 macro_rules! named_dimension(
     ($($D: ident),* $(,)*) => {$(
         /// A type level dimension.
-        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Debug, Copy, Clone, Hash, Eq)]
         #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
         pub struct $D;
 
@@ -280,6 +286,12 @@ macro_rules! named_dimension(
         }
 
         impl IsNotStaticOne for $D { }
+
+        impl<T: Dim> PartialEq<T> for $D {
+            fn eq(&self, other: &T) -> bool {
+                self.value() == other.value()
+            }
+        }
     )*}
 );
 
@@ -367,6 +379,23 @@ impl<
 {
 }
 
+impl<
+        T: Dim,
+        A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        C: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        D: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        E: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        F: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+        G: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
+    > PartialEq<T>
+    for UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, A>, B>, C>, D>, E>, F>, G>
+{
+    fn eq(&self, other: &T) -> bool {
+        self.value() == other.value()
+    }
+}
+
 impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> NamedDim
     for UInt<U, B>
 {
@@ -407,4 +436,16 @@ impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Syn
 impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> IsNotStaticOne
     for UInt<U, B>
 {
+}
+
+impl<
+        T: Dim,
+        U: Unsigned + DimName,
+        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync
+    > PartialEq<T>
+    for UInt<U, B>
+{
+    fn eq(&self, other: &T) -> bool {
+        self.value() == other.value()
+    }
 }

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -247,66 +247,6 @@ impl NamedDim for typenum::U1 {
     type Name = U1;
 }
 
-macro_rules! named_dimension(
-    ($($D: ident),* $(,)*) => {$(
-        /// A type level dimension.
-        #[derive(Debug, Copy, Clone, Hash, Eq)]
-        #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-        pub struct $D;
-
-        impl Dim for $D {
-            #[inline]
-            fn try_to_usize() -> Option<usize> {
-                Some(typenum::$D::to_usize())
-            }
-
-            #[inline]
-            fn from_usize(dim: usize) -> Self {
-                assert!(dim == typenum::$D::to_usize(), "Mismatched dimension.");
-                $D
-            }
-
-            #[inline]
-            fn value(&self) -> usize {
-                typenum::$D::to_usize()
-            }
-        }
-
-        impl DimName for $D {
-            type Value = typenum::$D;
-
-            #[inline]
-            fn name() -> Self {
-                $D
-            }
-        }
-
-        impl NamedDim for typenum::$D {
-            type Name = $D;
-        }
-
-        impl IsNotStaticOne for $D { }
-
-        impl<T: Dim> PartialEq<T> for $D {
-            fn eq(&self, other: &T) -> bool {
-                self.value() == other.value()
-            }
-        }
-    )*}
-);
-
-// We give explicit names to all Unsigned in [0, 128[
-named_dimension!(
-    U0, /*U1,*/ U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18,
-    U19, U20, U21, U22, U23, U24, U25, U26, U27, U28, U29, U30, U31, U32, U33, U34, U35, U36, U37,
-    U38, U39, U40, U41, U42, U43, U44, U45, U46, U47, U48, U49, U50, U51, U52, U53, U54, U55, U56,
-    U57, U58, U59, U60, U61, U62, U63, U64, U65, U66, U67, U68, U69, U70, U71, U72, U73, U74, U75,
-    U76, U77, U78, U79, U80, U81, U82, U83, U84, U85, U86, U87, U88, U89, U90, U91, U92, U93, U94,
-    U95, U96, U97, U98, U99, U100, U101, U102, U103, U104, U105, U106, U107, U108, U109, U110,
-    U111, U112, U113, U114, U115, U116, U117, U118, U119, U120, U121, U122, U123, U124, U125, U126,
-    U127
-);
-
 // For values greater than U1023, just use the typenum binary representation directly.
 impl<
         A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
@@ -379,23 +319,6 @@ impl<
 {
 }
 
-impl<
-        T: Dim,
-        A: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        C: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        D: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        E: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        F: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-        G: Bit + Any + Debug + Copy + PartialEq + Send + Sync,
-    > PartialEq<T>
-    for UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, A>, B>, C>, D>, E>, F>, G>
-{
-    fn eq(&self, other: &T) -> bool {
-        self.value() == other.value()
-    }
-}
-
 impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Sync> NamedDim
     for UInt<U, B>
 {
@@ -438,14 +361,62 @@ impl<U: Unsigned + DimName, B: Bit + Any + Debug + Copy + PartialEq + Send + Syn
 {
 }
 
-impl<
-        T: Dim,
-        U: Unsigned + DimName,
-        B: Bit + Any + Debug + Copy + PartialEq + Send + Sync
-    > PartialEq<T>
-    for UInt<U, B>
-{
-    fn eq(&self, other: &T) -> bool {
-        self.value() == other.value()
-    }
-}
+macro_rules! named_dimension(
+    ($($D: ident),* $(,)*) => {$(
+        /// A type level dimension.
+        #[derive(Debug, Copy, Clone, Hash, Eq)]
+        #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+        pub struct $D;
+
+        impl Dim for $D {
+            #[inline]
+            fn try_to_usize() -> Option<usize> {
+                Some(typenum::$D::to_usize())
+            }
+
+            #[inline]
+            fn from_usize(dim: usize) -> Self {
+                assert!(dim == typenum::$D::to_usize(), "Mismatched dimension.");
+                $D
+            }
+
+            #[inline]
+            fn value(&self) -> usize {
+                typenum::$D::to_usize()
+            }
+        }
+
+        impl DimName for $D {
+            type Value = typenum::$D;
+
+            #[inline]
+            fn name() -> Self {
+                $D
+            }
+        }
+
+        impl NamedDim for typenum::$D {
+            type Name = $D;
+        }
+
+        impl IsNotStaticOne for $D { }
+
+        impl<T: Dim> PartialEq<T> for $D {
+            fn eq(&self, other: &T) -> bool {
+                self.value() == other.value()
+            }
+        }
+    )*}
+);
+
+// We give explicit names to all Unsigned in [0, 128[
+named_dimension!(
+    U0, /*U1,*/ U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18,
+    U19, U20, U21, U22, U23, U24, U25, U26, U27, U28, U29, U30, U31, U32, U33, U34, U35, U36, U37,
+    U38, U39, U40, U41, U42, U43, U44, U45, U46, U47, U48, U49, U50, U51, U52, U53, U54, U55, U56,
+    U57, U58, U59, U60, U61, U62, U63, U64, U65, U66, U67, U68, U69, U70, U71, U72, U73, U74, U75,
+    U76, U77, U78, U79, U80, U81, U82, U83, U84, U85, U86, U87, U88, U89, U90, U91, U92, U93, U94,
+    U95, U96, U97, U98, U99, U100, U101, U102, U103, U104, U105, U106, U107, U108, U109, U110,
+    U111, U112, U113, U114, U115, U116, U117, U118, U119, U120, U121, U122, U123, U124, U125, U126,
+    U127,
+);

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1356,10 +1356,7 @@ where
 {
     #[inline]
     fn eq(&self, right: &Matrix<N, R2, C2, S2>) -> bool {
-        if self.shape() == right.shape() {
-            return self.iter().zip(right.iter()).all(|(l, r)| l == r)
-        }
-        false
+        self.shape() == right.shape() && self.iter().zip(right.iter()).all(|(l, r)| l == r)
     }
 }
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1137,7 +1137,7 @@ impl<N: Scalar + Zero + One, D: DimAdd<U1> + IsNotStaticOne, S: Storage<N, D, D>
     where DefaultAllocator: Allocator<N, DimSum<D, U1>, DimSum<D, U1>> {
         assert!(self.is_square(), "Only square matrices can currently be transformed to homogeneous coordinates.");
         let dim = DimSum::<D, U1>::from_usize(self.nrows() + 1);
-        let mut res = MatrixN::identity_generic(dim, dim); 
+        let mut res = MatrixN::identity_generic(dim, dim);
         res.generic_slice_mut::<D, D>((0, 0), self.data.shape()).copy_from(&self);
         res
     }

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1350,12 +1350,11 @@ where
     S: Storage<N, R, C>,
 {
     #[inline]
-    fn eq(&self, right: &Matrix<N, R, C, S>) -> bool {
-        assert!(
-            self.shape() == right.shape(),
-            "Matrix equality test dimension mismatch."
-        );
-        self.iter().zip(right.iter()).all(|(l, r)| l == r)
+    fn eq(&self, right: &Matrix<N, R2, C2, S2>) -> bool {
+        if self.shape() == right.shape() {
+            return self.iter().zip(right.iter()).all(|(l, r)| l == r)
+        }
+        false
     }
 }
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1347,9 +1347,9 @@ where
 impl<N, R, R2, C, C2, S, S2> PartialEq<Matrix<N, R2, C2, S2>> for Matrix<N, R, C, S>
 where
     N: Scalar + PartialEq,
-    C: Dim + PartialEq<C2>,
+    C: Dim,
     C2: Dim,
-    R: Dim + PartialEq<R2>,
+    R: Dim,
     R2: Dim,
     S: Storage<N, R, C>,
     S2: Storage<N, R2, C2>

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1344,10 +1344,15 @@ where
     S: Storage<N, R, C>,
 {}
 
-impl<N, R: Dim, C: Dim, S> PartialEq for Matrix<N, R, C, S>
+impl<N, R, R2, C, C2, S, S2> PartialEq<Matrix<N, R2, C2, S2>> for Matrix<N, R, C, S>
 where
-    N: Scalar,
+    N: Scalar + PartialEq,
+    C: Dim + PartialEq<C2>,
+    C2: Dim,
+    R: Dim + PartialEq<R2>,
+    R2: Dim,
     S: Storage<N, R, C>,
+    S2: Storage<N, R2, C2>
 {
     #[inline]
     fn eq(&self, right: &Matrix<N, R2, C2, S2>) -> bool {

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -7,6 +7,9 @@ use na::{
     Matrix4x3, Matrix4x5, Matrix5, Matrix6, MatrixMN, RowVector3, RowVector4, RowVector5,
     Vector1, Vector2, Vector3, Vector4, Vector5, Vector6,
 };
+use typenum::{UInt, UTerm};
+use serde_json::error::Category::Data;
+use typenum::bit::{B0, B1};
 
 #[test]
 fn iter() {
@@ -1053,6 +1056,9 @@ fn partial_eq() {
     let dynamic_mat = DMatrix::from_row_slice(2, 4, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let static_mat = Matrix2x4::new(1, 2, 3, 4, 5, 6, 7, 8);
 
+    type TypeNumInt = typenum::UInt<UInt<UTerm, B0>, B1>;
+    let typenum_static_mat = MatrixMN::<u8, typenum::U1024, U4>::new(1, 2, 3, 4, 5, 6, 7, 8);
+
     let dyn_static_slice = dynamic_mat.fixed_slice::<U2, U2>(0, 0);
     let dyn_dyn_slice = dynamic_mat.slice((0, 0), (2, 2));
     let static_static_slice = static_mat.fixed_slice::<U2, U2>(0, 0);
@@ -1061,6 +1067,8 @@ fn partial_eq() {
     let larger_slice = static_mat.slice((0, 0), (2, 3));
     
     assert_eq!(dynamic_mat, static_mat);
+    assert_eq!(dynamic_mat, typenum_static_mat);
+    assert_eq!(typenum_static_mat, static_mat);
 
     assert_eq!(dyn_static_slice, dyn_dyn_slice);
     assert_eq!(dyn_static_slice, static_static_slice);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1065,27 +1065,47 @@ fn partial_eq_different_types() {
     let dynamic_mat = DMatrix::from_row_slice(2, 4, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let static_mat = Matrix2x4::new(1, 2, 3, 4, 5, 6, 7, 8);
 
-    type TypeNumInt = typenum::UInt<UInt<UTerm, B0>, B1>;
-    let typenum_static_mat = MatrixMN::<u8, typenum::U1024, U4>::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let mut typenum_static_mat = MatrixMN::<u8, typenum::U1024, U4>::zeros();
+    let mut slice = typenum_static_mat.slice_mut((0,0), (2, 4));
+    slice += static_mat;
 
-    let dyn_static_slice = dynamic_mat.fixed_slice::<U2, U2>(0, 0);
-    let dyn_dyn_slice = dynamic_mat.slice((0, 0), (2, 2));
-    let static_static_slice = static_mat.fixed_slice::<U2, U2>(0, 0);
-    let static_dyn_slice = static_mat.slice((0, 0), (2, 2));
+    let fslice_of_dmat = dynamic_mat.fixed_slice::<U2, U2>(0, 0);
+    let dslice_of_dmat = dynamic_mat.slice((0, 0), (2, 2));
+    let fslice_of_smat = static_mat.fixed_slice::<U2, U2>(0, 0);
+    let dslice_of_smat = static_mat.slice((0, 0), (2, 2));
 
-    let larger_slice = static_mat.slice((0, 0), (2, 3));
-    
     assert_eq!(dynamic_mat, static_mat);
-    assert_eq!(dynamic_mat, typenum_static_mat);
-    assert_eq!(typenum_static_mat, static_mat);
+    assert_eq!(static_mat, dynamic_mat);
 
-    assert_eq!(dyn_static_slice, dyn_dyn_slice);
-    assert_eq!(dyn_static_slice, static_static_slice);
-    assert_eq!(dyn_static_slice, static_dyn_slice);
-    assert_eq!(dyn_dyn_slice, static_static_slice);
-    assert_eq!(dyn_dyn_slice, static_dyn_slice);
-    assert_eq!(static_static_slice, static_dyn_slice);
+    assert_eq!(dynamic_mat, slice);
+    assert_eq!(slice, dynamic_mat);
 
-    assert_ne!(dynamic_mat, static_dyn_slice);
-    assert_ne!(static_dyn_slice, larger_slice);
+    assert_eq!(static_mat, slice);
+    assert_eq!(slice, static_mat);
+
+    assert_eq!(fslice_of_dmat, dslice_of_dmat);
+    assert_eq!(dslice_of_dmat, fslice_of_dmat);
+
+    assert_eq!(fslice_of_dmat, fslice_of_smat);
+    assert_eq!(fslice_of_smat, fslice_of_dmat);
+
+    assert_eq!(fslice_of_dmat, dslice_of_smat);
+    assert_eq!(dslice_of_smat, fslice_of_dmat);
+
+    assert_eq!(dslice_of_dmat, fslice_of_smat);
+    assert_eq!(fslice_of_smat, dslice_of_dmat);
+
+    assert_eq!(dslice_of_dmat, dslice_of_smat);
+    assert_eq!(dslice_of_smat, dslice_of_dmat);
+
+    assert_eq!(fslice_of_smat, dslice_of_smat);
+    assert_eq!(dslice_of_smat, fslice_of_smat);
+
+    assert_ne!(dynamic_mat, dslice_of_smat);
+    assert_ne!(dslice_of_smat, dynamic_mat);
+
+    // TODO - implement those comparisons
+    // assert_ne!(static_mat, typenum_static_mat);
+    //assert_ne!(typenum_static_mat, static_mat);
+
 }

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1,7 +1,7 @@
 use num::{One, Zero};
 use std::cmp::Ordering;
 
-use na::dimension::{U15, U8};
+use na::dimension::{U15, U8, U2};
 use na::{
     self, DMatrix, DVector, Matrix2, Matrix2x3, Matrix2x4, Matrix3, Matrix3x2, Matrix3x4, Matrix4,
     Matrix4x3, Matrix4x5, Matrix5, Matrix6, MatrixMN, RowVector3, RowVector4, RowVector5,
@@ -1046,4 +1046,29 @@ mod finite_dim_inner_space_tests {
 
         true
     }
+}
+
+#[test]
+fn partial_eq() {
+    let dynamic_mat = DMatrix::from_row_slice(2, 4, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    let static_mat = Matrix2x4::new(1, 2, 3, 4, 5, 6, 7, 8);
+
+    let dyn_static_slice = dynamic_mat.fixed_slice::<U2, U2>(0, 0);
+    let dyn_dyn_slice = dynamic_mat.slice((0, 0), (2, 2));
+    let static_static_slice = static_mat.fixed_slice::<U2, U2>(0, 0);
+    let static_dyn_slice = static_mat.slice((0, 0), (2, 2));
+
+    let larger_slice = static_mat.slice((0, 0), (2, 3));
+    
+    assert_eq!(dynamic_mat, static_mat);
+
+    assert_eq!(dyn_static_slice, dyn_dyn_slice);
+    assert_eq!(dyn_static_slice, static_static_slice);
+    assert_eq!(dyn_static_slice, static_dyn_slice);
+    assert_eq!(dyn_dyn_slice, static_static_slice);
+    assert_eq!(dyn_dyn_slice, static_dyn_slice);
+    assert_eq!(static_static_slice, static_dyn_slice);
+
+    assert_ne!(dynamic_mat, static_dyn_slice);
+    assert_ne!(static_dyn_slice, larger_slice);
 }

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1,7 +1,7 @@
 use num::{One, Zero};
 use std::cmp::Ordering;
 
-use na::dimension::{U15, U8, U2};
+use na::dimension::{U15, U8, U2, U4};
 use na::{
     self, DMatrix, DVector, Matrix2, Matrix2x3, Matrix2x4, Matrix3, Matrix3x2, Matrix3x4, Matrix4,
     Matrix4x3, Matrix4x5, Matrix5, Matrix6, MatrixMN, RowVector3, RowVector4, RowVector5,
@@ -1052,7 +1052,16 @@ mod finite_dim_inner_space_tests {
 }
 
 #[test]
-fn partial_eq() {
+fn partial_eq_shape_mismatch() {
+    let a = Matrix2::new(1, 2, 3, 4);
+    let b = Matrix2x3::new(1, 2, 3, 4, 5, 6);
+    assert_ne!(a, b);
+    assert_ne!(b, a);
+}
+
+#[test]
+fn partial_eq_different_types() {
+    // Ensure comparability of several types of Matrices
     let dynamic_mat = DMatrix::from_row_slice(2, 4, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let static_mat = Matrix2x4::new(1, 2, 3, 4, 5, 6, 7, 8);
 

--- a/tests/core/serde.rs
+++ b/tests/core/serde.rs
@@ -14,7 +14,8 @@ macro_rules! test_serde(
         fn $test() {
             let v: $ty<f32> = rand::random();
             let serialized = serde_json::to_string(&v).unwrap();
-            assert_eq!(v, serde_json::from_str(&serialized).unwrap());
+            let deserialized: $ty<f32> = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(v, deserialized);
         }
     )*}
 );
@@ -23,7 +24,8 @@ macro_rules! test_serde(
 fn serde_dmatrix() {
     let v: DMatrix<f32> = DMatrix::new_random(3, 4);
     let serialized = serde_json::to_string(&v).unwrap();
-    assert_eq!(v, serde_json::from_str(&serialized).unwrap());
+    let deserialized: DMatrix<f32> = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(v, deserialized);
 }
 
 test_serde!(


### PR DESCRIPTION
Addresses #674 (at least partly)

## What's new
- `matrix_a == matrix_b` will no longer panic when shapes mismatch.
- In addition, comparison can be done if the number of rows / columns or storage are of different types (static vs dynamic, owned vs slice).

## What's left to do
PartialEq trait for Matrices with `typenum`-typed number of rows and / or columns is not implemented symmetrically.
In other words, comparing two matrices with a `typenum`-typed Matrix on the left hand side of the `==` operator will work, but not if it is on the right hand side of the operator (compilation error).

This is because 
```
impl<
    T: Dim,
    U: ...,
    B: ...
> PartialEq<UInt<U, B>> for T { ...}
```
violates Rust orphan rules for Trait implementation (see error `E0210`), and I could not find a way to work around it. Using a local struct to cover the type seems not a good idea, as we lose all trait implementation done in `typenum` crate.

Any idea to solve this issue is welcome !