### PR TITLE
GivensRotation::new() should default to (I, 0)

### DIFF
--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -38,7 +38,8 @@ impl<N: ComplexField> GivensRotation<N> {
 
     /// Initializes a Givens rotation from its non-normalized cosine an sine components.
     pub fn new(c: N, s: N) -> (Self, N) {
-        Self::try_new(c, s, N::RealField::zero()).unwrap()
+        Self::try_new(c, s, N::RealField::zero())
+            .unwrap_or_else(|| (GivensRotation::identity(), N::zero()))
     }
 
     /// Initializes a Givens rotation form its non-normalized cosine an sine components.


### PR DESCRIPTION
The bug was introduced in b5f452087e3367b60dfc097078c5862f17bd8dc9
SVD sometimes fails trying to do `None.unwrap()` in `GivensRotation::new()`
