### PR TITLE
Small docs improvements

### DIFF
--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -16,7 +16,7 @@ use crate::base::{Matrix4, Vector, Vector3};
 
 use crate::geometry::{Point3, Projective3};
 
-/// A 3D orthographic projection stored as an homogeneous 4x4 matrix.
+/// A 3D orthographic projection stored as a homogeneous 4x4 matrix.
 pub struct Orthographic3<N: RealField> {
     matrix: Matrix4<N>,
 }

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -17,7 +17,7 @@ use crate::base::{Matrix4, Scalar, Vector, Vector3};
 
 use crate::geometry::{Point3, Projective3};
 
-/// A 3D perspective projection stored as an homogeneous 4x4 matrix.
+/// A 3D perspective projection stored as a homogeneous 4x4 matrix.
 pub struct Perspective3<N: Scalar> {
     matrix: Matrix4<N>,
 }
@@ -89,7 +89,7 @@ impl<N: RealField> Perspective3<N> {
 
     /// Wraps the given matrix to interpret it as a 3D perspective matrix.
     ///
-    /// It is not checked whether or not the given matrix actually represents an orthographic
+    /// It is not checked whether or not the given matrix actually represents a perspective
     /// projection.
     #[inline]
     pub fn from_matrix_unchecked(matrix: Matrix4<N>) -> Self {

--- a/src/geometry/transform_alias.rs
+++ b/src/geometry/transform_alias.rs
@@ -2,16 +2,16 @@ use crate::base::dimension::{U2, U3};
 
 use crate::geometry::{TAffine, TGeneral, TProjective, Transform};
 
-/// A 2D general transformation that may not be invertible. Stored as an homogeneous 3x3 matrix.
+/// A 2D general transformation that may not be invertible. Stored as a homogeneous 3x3 matrix.
 pub type Transform2<N> = Transform<N, U2, TGeneral>;
-/// An invertible 2D general transformation. Stored as an homogeneous 3x3 matrix.
+/// An invertible 2D general transformation. Stored as a homogeneous 3x3 matrix.
 pub type Projective2<N> = Transform<N, U2, TProjective>;
-/// A 2D affine transformation. Stored as an homogeneous 3x3 matrix.
+/// A 2D affine transformation. Stored as a homogeneous 3x3 matrix.
 pub type Affine2<N> = Transform<N, U2, TAffine>;
 
-/// A 3D general transformation that may not be inversible. Stored as an homogeneous 4x4 matrix.
+/// A 3D general transformation that may not be inversible. Stored as a homogeneous 4x4 matrix.
 pub type Transform3<N> = Transform<N, U3, TGeneral>;
-/// An invertible 3D general transformation. Stored as an homogeneous 4x4 matrix.
+/// An invertible 3D general transformation. Stored as a homogeneous 4x4 matrix.
 pub type Projective3<N> = Transform<N, U3, TProjective>;
-/// A 3D affine transformation. Stored as an homogeneous 4x4 matrix.
+/// A 3D affine transformation. Stored as a homogeneous 4x4 matrix.
 pub type Affine3<N> = Transform<N, U3, TAffine>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ an optimized set of tools for computer graphics and physics. Those features incl
   allocated on the heap.
 * Convenient aliases for low-dimensional matrices and vectors: `Vector1` to `Vector6` and
   `Matrix1x1` to `Matrix6x6`, including rectangular matrices like `Matrix2x5`.
-* Points sizes known at compile time, and convenience aliases:: `Point1` to `Point6`.
+* Points sizes known at compile time, and convenience aliases: `Point1` to `Point6`.
 * Translation (seen as a transformation that composes by multiplication): `Translation2`,
   `Translation3`.
 * Rotation matrices: `Rotation2`, `Rotation3`.
@@ -60,10 +60,10 @@ an optimized set of tools for computer graphics and physics. Those features incl
 * Algebraic entities with a norm equal to one: `Unit<T>`, e.g., `Unit<Vector3<f32>>`.
 * Isometries (translation ⨯ rotation): `Isometry2`, `Isometry3`
 * Similarity transformations (translation ⨯ rotation ⨯ uniform scale): `Similarity2`, `Similarity3`.
-* Affine transformations stored as an homogeneous matrix: `Affine2`, `Affine3`.
-* Projective (i.e. invertible) transformations stored as an homogeneous matrix: `Projective2`,
+* Affine transformations stored as a homogeneous matrix: `Affine2`, `Affine3`.
+* Projective (i.e. invertible) transformations stored as a homogeneous matrix: `Projective2`,
   `Projective3`.
-* General transformations that does not have to be invertible, stored as an homogeneous matrix:
+* General transformations that does not have to be invertible, stored as a homogeneous matrix:
   `Transform2`, `Transform3`.
 * 3D projections for computer graphics: `Perspective3`, `Orthographic3`.
 * Matrix factorizations: `Cholesky`, `QR`, `LU`, `FullPivLU`, `SVD`, `Schur`, `Hessenberg`, `SymmetricEigen`.


### PR DESCRIPTION
* The `Perspective3` docs mentioned an "orthographic" projection where it should say "perspective"
* Replaced "an homogeneous" by "a homogeneous"
* Removed a double colon in lib.rs:54