### PR TITLE
Unnecessary Trait bound DimSub<Dynamic> in impl Cholesky

### DIFF
--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -37,7 +37,7 @@ where
 {
 }
 
-impl<N: ComplexField, D: DimSub<Dynamic>> Cholesky<N, D>
+impl<N: ComplexField, D: Dim> Cholesky<N, D>
 where
     DefaultAllocator: Allocator<N, D, D>,
 {


### PR DESCRIPTION
Looks like the bound is unnecessary as there is no use of DimDiff in the implementation.
Integration tests are OK with it replaced by a simple Dim