### PR TITLE
Fix compilation of matrix exponential when targetting no-std.

### DIFF
--- a/src/linalg/exp.rs
+++ b/src/linalg/exp.rs
@@ -42,8 +42,7 @@ impl<N, D> ExpmPadeHelper<N, D>
 where
     N: RealField,
     D: DimMin<D>,
-    DefaultAllocator:
-        Allocator<N, D, D> + Allocator<N, D> + Allocator<(usize, usize), DimMinimum<D, D>>,
+    DefaultAllocator: Allocator<N, D, D> + Allocator<(usize, usize), DimMinimum<D, D>>,
 {
     fn new(a: MatrixN<N, D>, use_exact_norm: bool) -> Self {
         let (nrows, ncols) = a.data.shape();


### PR DESCRIPTION
Because the CI was not configured properly, it did not run properly on  #708, causing a compilation failure when targeting no-std. This PR fixes this compilation issue.