### PR TITLE
Empty rustfmt.toml.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-unstable_features = true
-indent_style = "Block"
-where_single_line = true


### PR DESCRIPTION
The CI rustfmt checker uses `stable` rust, not `nightly`, but the config options in `rustfmt.toml` only work on nightly -- on stable, there are ignored with warnings. This means that devs running stable get a lot of warnings and devs running nightly will accidentally format in a way that the CI checker forbids. (specifically, using `where_single_line`). E.g.:

```
$ cargo +stable fmt -- --check
Warning: can't set `indent_style = Block`, unstable features are only available in nightly channel.
Warning: can't set `where_single_line = true`, unstable features are only available in nightly channel.
...etc

$ cargo +nightly fmt -- --check
-where
-    N: RealField,
-{
+where N: RealField {
...etc
```

Just removing the toml fixes this problem.